### PR TITLE
chore: temp disable sarif upload until public

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cat *-scan-results.sarif
 
-      - name: Upload sarif file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "./"
+      # - name: Upload sarif file
+      #   uses: github/codeql-action/upload-sarif@v3
+      #   with:
+      #     sarif_file: "./"


### PR DESCRIPTION
Private repo's don't support this for us right now, so we will undo this once we go public