### PR TITLE
fix: use bin from container to fix permission issues

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -1,9 +1,17 @@
 name: Test Action (push)
 
-on: [push]
+on:
+  push:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   fcs-scan:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request_target' &&
+      github.event.label.name == 'ok-to-test')
     runs-on: ubuntu-latest
     permissions:
       # required for all workflows

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -15,21 +15,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create scan results directory
+        run: mkdir scan-results
+
       - name: Test FCS CLI IaC Scan
         uses: ./
         with:
           falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
           falcon_region: ${{ vars.FALCON_CLOUD_REGION }}
           path: tests/
+          output_path: scan-results/
           report_formats: sarif
         env:
           FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 
       - name: Show scan results
         run: |
-          cat *-scan-results.sarif
+          cat scan-results/*.sarif
 
       - name: Upload sarif file
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: "./"
+          sarif_file: "./scan-results"

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       run: $GITHUB_ACTION_PATH/fcs-scan.sh
       shell: bash
       env:
-        OUTPUT_FCS_IMAGE: ${{ steps.fcs-pull.outputs.FCS_IMAGE }}
+        OUTPUT_FCS_BIN: ${{ steps.fcs-pull.outputs.FCS_BIN }}
         INPUT_FALCON_CLIENT_ID: ${{ inputs.falcon_client_id }}
         INPUT_FALCON_REGION: ${{ inputs.falcon_region }}
         INPUT_CATEGORIES: ${{ inputs.categories }}

--- a/fcs-pull.sh
+++ b/fcs-pull.sh
@@ -38,4 +38,4 @@ if [ ! -f $FCS_BIN_PATH/fcs ]; then
 fi
 
 # Set the bin path as an output
-echo "::set-output name=FCS_BIN::$FCS_BIN_PATH/fcs"
+echo "FCS_BIN=$FCS_BIN_PATH/fcs" >> $GITHUB_OUTPUT

--- a/fcs-pull.sh
+++ b/fcs-pull.sh
@@ -24,5 +24,18 @@ if [ -z "$image_name" ]; then
     exit 1
 fi
 
-# Set the image name as an output for the next step to use
-echo "FCS_IMAGE=$image_name" >> $GITHUB_OUTPUT
+# TBD: For the container image, let's extract and copy the binary
+FCS_BIN_PATH=/opt/crowdstrike/bin
+# Make sure the directory exists
+mkdir -p $FCS_BIN_PATH
+id=$(docker create "$image_name")
+docker cp $id:$FCS_BIN_PATH/fcs $FCS_BIN_PATH
+
+# Ensure the binary exists
+if [ ! -f $FCS_BIN_PATH/fcs ]; then
+    echo "Failed to copy the FCS binary."
+    exit 1
+fi
+
+# Set the bin path as an output
+echo "::set-output name=FCS_BIN::$FCS_BIN_PATH/fcs"

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -2,8 +2,7 @@
 # This script is used to execute the FCS CLI tool with the provided arguments.
 # Current context is executing the FCS CLI container.
 
-readonly FCS_CLI_BIN="/opt/crowdstrike/bin/fcs"
-readonly FCS_IMAGE="${OUTPUT_FCS_IMAGE:-}"
+readonly FCS_CLI_BIN="${OUTPUT_FCS_BIN:-}"
 
 # TODO: Remove these functions when upstream fix is in place
 check_sarif() {
@@ -142,17 +141,11 @@ set_parameters() {
 
 execute_fcs_cli() {
     local args="$1"
-    local fcs_image="${FCS_IMAGE}"
-    [[ -n "$fcs_image" ]] || die "OUTPUT_FCS_IMAGE is not set. Ensure the FCS CLI container image was pulled successfully."
 
-    setfacl -m u:999:rwx "$GITHUB_WORKSPACE" || die "Failed to set permissions for container user."
     cd "$GITHUB_WORKSPACE" || die "Failed to change directory to $GITHUB_WORKSPACE"
 
-    local docker_command
-    docker_command="docker run --rm --platform linux/amd64 -v $(pwd):/workdir -w /workdir --entrypoint $FCS_CLI_BIN $fcs_image"
-
     log "Executing FCS CLI tool with the following arguments: $args"
-    $docker_command iac scan $args
+    $FCS_CLI_BIN iac scan $args
     local exit_code=$?
 
     echo "exit-code=$exit_code" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes #20 

This PR fixes dealing with permission issues due to using a container image to fun the binary. Instead, we can extract the binary from the container image and run that locally to prevent permission when reading/writing results to a certain directory.

This also prepares the GH action to eventually move away from pulling the container from the registry, to pulling the binary from our new APIs.

---

Also adds safety mechanisms for working with pull_request_targets since we are using secrets.