### PR TITLE
feat: add new policy_rule option and doc changes for newer cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ This action relies on the environment variable `FALCON_CLIENT_SECRET` to authent
 
 Create a GitHub secret in your repository to store the CrowdStrike API Client secret created from the step above. For more information, see [Creating secrets for a repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
 
+### FCS Action Support for FCS CLI Versions
+
+| **FCS CLI Version** | **FCS Action Version** |
+| ------------------- | ---------------------- |
+| **`>= 1.0.0`**      | **`>= 1.1.0`**         |
+| **`< 1.0.0`**       | **`< 1.1.0`**          |
+
 ## Usage
 
 To use this action in your workflow, add the following step:
@@ -44,63 +51,41 @@ To use this action in your workflow, add the following step:
 ```
 <!-- x-release-please-end -->
 
-> [!IMPORTANT]
-> **Understanding Version Differences**
->
-> There are two different version numbers to be aware of:
->
-> 1. **GitHub Action Version** (`crowdstrike/fcs-action@v1.0.6`) - This is the version of the GitHub Action wrapper.
-> 2. **FCS CLI Version** (specified with the `version` parameter) - This is the version of the underlying scanning tool.
->
-> **FCS CLI Version Changes**
->
-> The underlying FCS CLI tool has significant changes between versions. If no `version` parameter is specified, the latest FCS CLI version (currently v1.0.0) is used by default.
->
-> Key changes in FCS CLI v1.0.0:
->
-> - **Severity levels**: Changed from `high|medium|low|info` to `critical|high|medium|informational`
-> - **Default fail-on values**: Changed from `high=1,medium=1,low=1,info=1` to `critical=1,high=1,medium=1,informational=1`
-> - **Supported platforms**: Removed support for ***Buildah*** and ***Knative***
-> - **Default timeout**: Increased from 300 seconds to 500 seconds
-> - **Added new parameter**: `policy_rule` for specifying IaC cloud scanning policy-rule
->
-> To use an older FCS CLI version, specify the `version` parameter (e.g., `version: '0.47.1'`).
-
 ## Environment Variables
 
-| Variable | Description | Required | Default | Example/Allowed Values |
-|----------|-------------|----------|---------|---------|
-| `FALCON_CLIENT_SECRET` | CrowdStrike API Client Secret for authentication | **Yes** | - | `${{ secrets.FALCON_CLIENT_SECRET }}` |
+| Variable               | Description                                      | Required | Default | Example/Allowed Values                |
+| ---------------------- | ------------------------------------------------ | -------- | ------- | ------------------------------------- |
+| `FALCON_CLIENT_SECRET` | CrowdStrike API Client Secret for authentication | **Yes**  | -       | `${{ secrets.FALCON_CLIENT_SECRET }}` |
 
 ## Inputs
 
-| Input | Description | Required | Default | Example/Allowed Values |
-|-------|-------------|----------|---------|---------|
-| `falcon_client_id` | CrowdStrike API Client ID for authentication | **Yes** | - | `${{ vars.FALCON_CLIENT_ID }}` |
-| `falcon_region` | CrowdStrike API region | **Yes** | `us-1` | Allowed values: `us-1, us-2, eu-1, us-gov-1, us-gov-2` |
-| `version` | **FCS CLI tool** version to use (_not the GitHub Action version_) | No | - | `0.47.1` |
-| `categories` | Include results for the specified categories, accepts a comma-separated list | No | - | `Access Control,Best Practices` |
-| `config` | Path to the scan configuration file | No | - | `./fcs-config.json` |
-| `disable_secrets_scan` | Disable scanning of secrets and passwords in target files | No | `false` | Allowed values: `true, false` |
-| `exclude_categories` | Exclude results for the specified categories, accepts a comma-separated list | No | - | Allowed values: `Access Control, Availability, Backup, Best Practices, Build Process, Encryption, Insecure Configurations, Insecure Defaults, Networking and Firewall, Observability, Resource Management, Secret Management, Supply-Chain, Structure and Semantics` |
-| `exclude_paths` | Exclude paths from scan | No | - | `./sample-dir-to-omit/*,sample-file.tf` |
-| `exclude_platforms` | Exclude results for the specified platforms, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`<br>FCS CLI <v1.0.0: Also includes `Buildah, Knative` |
-| `exclude_severities` | Exclude results for the specified severities, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `critical, high, medium, informational`<br>FCS CLI <v1.0.0: `high, medium, low, info` |
-| `fail_on` | Which kind of results should return a non-zero exit code, accepts a comma-separated list of `<severity>=<value>` | No | FCS CLI v1.0.0+: `critical=1,high=1,medium=1,informational=1`<br>FCS CLI <v1.0.0: `high=1,medium=1,low=1,info=1` | `"high=2,medium=50"` |
-| `output_path` | Path to save the scan results | No | `./` | `./scan-results` |
-| `path` | Path to local file, directory or git repo to scan | No | - | `./my-local-dir, git::<git repo>, sample-file.tf` |
-| `platforms` | Include results for the specified platforms, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`<br>FCS CLI <v1.0.0: Also includes `Buildah, Knative` |
-| `policy_rule` | IaC cloud scanning policy-rule (_FCS CLI v1.0.0+ only_) | No | `local` | `local`, `default-iac-alert-rule` |
-| `project_owners` | Comma-separated list of project owners to notify (max 5) | No | - | `john@example.com,jane@example.com` |
-| `report_formats` | Formats in which reports are to be written, accepts a comma-separated list | No | `json` | Allowed values: `json, csv, junit, sarif` |
-| `severities` | Include results for the specified severities, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `critical, high, medium, informational`<br>FCS CLI <v1.0.0: `high, medium, low, info` |
-| `timeout` | Timeout for the scan in seconds | No | FCS CLI v1.0.0+: `500`<br>FCS CLI <v1.0.0: `300` | `900` |
-| `upload_results` | Upload scan results to the CrowdStrike Falcon Console | No | `false` | `true` |
+| Input                  | Description                                                                                                      | Required | Default                                      | Example/Allowed Values                                                                                                                                                                                                                                               |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `falcon_client_id`     | CrowdStrike API Client ID for authentication                                                                     | **Yes**  | -                                            | `${{ vars.FALCON_CLIENT_ID }}`                                                                                                                                                                                                                                       |
+| `falcon_region`        | CrowdStrike API region                                                                                           | **Yes**  | `us-1`                                       | Allowed values: `us-1, us-2, eu-1, us-gov-1, us-gov-2`                                                                                                                                                                                                               |
+| `version`              | **FCS CLI tool** version to use (_not the GitHub Action version_)                                                | No       | -                                            | `1.0.0`                                                                                                                                                                                                                                                             |
+| `categories`           | Include results for the specified categories, accepts a comma-separated list                                     | No       | -                                            | `Access Control,Best Practices`                                                                                                                                                                                                                                      |
+| `config`               | Path to the scan configuration file                                                                              | No       | -                                            | `./fcs-config.json`                                                                                                                                                                                                                                                  |
+| `disable_secrets_scan` | Disable scanning of secrets and passwords in target files                                                        | No       | `false`                                      | Allowed values: `true, false`                                                                                                                                                                                                                                        |
+| `exclude_categories`   | Exclude results for the specified categories, accepts a comma-separated list                                     | No       | -                                            | Allowed values: `Access Control, Availability, Backup, Best Practices, Build Process, Encryption, Insecure Configurations, Insecure Defaults, Networking and Firewall, Observability, Resource Management, Secret Management, Supply-Chain, Structure and Semantics` |
+| `exclude_paths`        | Exclude paths from scan                                                                                          | No       | -                                            | `./sample-dir-to-omit/*,sample-file.tf`                                                                                                                                                                                                                              |
+| `exclude_platforms`    | Exclude results for the specified platforms, accepts a comma-separated list                                      | No       | -                                            | `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`                                                                                                |
+| `exclude_severities`   | Exclude results for the specified severities, accepts a comma-separated list                                     | No       | -                                            | Allowed values: `critical, high, medium, informational`                                                                                                                                                                                                                              |
+| `fail_on`              | Which kind of results should return a non-zero exit code, accepts a comma-separated list of `<severity>=<value>` | No       | `critical=1,high=1,medium=1,informational=1` |                                                                                                                                                                                                                                                                      |
+| `output_path`          | Path to save the scan results                                                                                    | No       | `./`                                         | `./scan-results`                                                                                                                                                                                                                                                     |
+| `path`                 | Path to local file, directory or git repo to scan                                                                | No       | -                                            | `./my-local-dir, git::<git repo>, sample-file.tf`                                                                                                                                                                                                                    |
+| `platforms`            | Include results for the specified platforms, accepts a comma-separated list                                      | No       | -                                            | `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`                                                                                                |
+| `policy_rule`          | IaC cloud scanning policy-rule                                                                                   | No       | `local`                                      | `local`, `default-iac-alert-rule`                                                                                                                                                                                                                                    |
+| `project_owners`       | Comma-separated list of project owners to notify (max 5)                                                         | No       | -                                            | `john@example.com,jane@example.com`                                                                                                                                                                                                                                  |
+| `report_formats`       | Formats in which reports are to be written, accepts a comma-separated list                                       | No       | `json`                                       | Allowed values: `json, csv, junit, sarif`                                                                                                                                                                                                                            |
+| `severities`           | Include results for the specified severities, accepts a comma-separated list                                     | No       | -                                            | Allowed values: `critical, high, medium, informational`                                                                                                                                                                                                                              |
+| `timeout`              | Timeout for the scan in seconds                                                                                  | No       | `500`                                        | `900`                                                                                                                                                                                                                                                                |
+| `upload_results`       | Upload scan results to the CrowdStrike Falcon Console                                                            | No       | `false`                                      | `true`                                                                                                                                                                                                                                                               |
 
 ## Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output      | Description                   |
+| ----------- | ----------------------------- |
 | `exit-code` | Exit code of the FCS CLI tool |
 
 ## Examples
@@ -119,7 +104,7 @@ To use this action in your workflow, add the following step:
 ```
 <!-- x-release-please-end -->
 
-### Using a specific FCS CLI version for compatibility with old severity levels
+### Using latest FCS CLI version with severity levels
 <!-- x-release-please-start-version -->
 ```yaml
 - name: Run FCS IaC Scan
@@ -127,15 +112,14 @@ To use this action in your workflow, add the following step:
   with:
     falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-2'
-    version: '0.47.1'  # FCS CLI tool version
     path: './kubernetes'
-    severities: 'medium,low'  # Using severity levels from older FCS CLI versions
+    severities: 'critical,high,medium'
   env:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```
 <!-- x-release-please-end -->
 
-### Using latest FCS CLI version with updated severity levels
+### Using the policy rule parameter
 <!-- x-release-please-start-version -->
 ```yaml
 - name: Run FCS IaC Scan
@@ -143,25 +127,8 @@ To use this action in your workflow, add the following step:
   with:
     falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-2'
-    # No version specified, will use latest FCS CLI tool version (v1.0.0)
     path: './kubernetes'
-    severities: 'critical,high,medium'  # Using severity levels from FCS CLI v1.0.0+
-  env:
-    FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
-```
-<!-- x-release-please-end -->
-
-### Using the new policy rule parameter (FCS CLI v1.0.0+ only)
-<!-- x-release-please-start-version -->
-```yaml
-- name: Run FCS IaC Scan
-  uses: crowdstrike/fcs-action@v1.0.6
-  with:
-    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
-    falcon_region: 'us-2'
-    # No version specified, will use latest FCS CLI tool version (v1.0.0)
-    path: './kubernetes'
-    policy_rule: 'default-iac-alert-rule'  # Parameter only available in FCS CLI v1.0.0+
+    policy_rule: 'default-iac-alert-rule'
   env:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ To use this action in your workflow, add the following step:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```
 <!-- x-release-please-end -->
+
+> [!IMPORTANT]
+> **FCS CLI Version Differences**
+>
+> The FCS CLI tool has significant changes between versions. If no version is specified, the latest version (currently v1.0.0) is used by default.
+>
+> Key changes in v1.0.0:
+>
+> - **Severity levels**: Changed from `high|medium|low|info` to `critical|high|medium|informational`
+> - **Default fail-on values**: Changed from `high=1,medium=1,low=1,info=1` to `critical=1,high=1,medium=1,informational=1`
+> - **Supported platforms**: Removed support for ***Buildah*** and ***Knative***
+> - **Default timeout**: Increased from 300 seconds to 500 seconds
+> - **Added new parameter**: `policy_rule` for specifying IaC cloud scanning policy-rule
+>
+> To use an older CLI version, specify the `version` parameter (e.g., `version: '0.47.1'`).
+
 ## Environment Variables
 
 | Variable | Description | Required | Default | Example/Allowed Values |
@@ -55,22 +71,23 @@ To use this action in your workflow, add the following step:
 |-------|-------------|----------|---------|---------|
 | `falcon_client_id` | CrowdStrike API Client ID for authentication | **Yes** | - | `${{ vars.FALCON_CLIENT_ID }}` |
 | `falcon_region` | CrowdStrike API region | **Yes** | `us-1` | Allowed values: `us-1, us-2, eu-1, us-gov-1, us-gov-2` |
-| `version` | FCS CLI version to use | No | - | `0.39.0` |
+| `version` | FCS CLI version to use | No | - | `0.47.1` |
 | `categories` | Include results for the specified categories, accepts a comma-separated list | No | - | `Access Control,Best Practices` |
 | `config` | Path to the scan configuration file | No | - | `./fcs-config.json` |
 | `disable_secrets_scan` | Disable scanning of secrets and passwords in target files | No | `false` | Allowed values: `true, false` |
 | `exclude_categories` | Exclude results for the specified categories, accepts a comma-separated list | No | - | Allowed values: `Access Control, Availability, Backup, Best Practices, Build Process, Encryption, Insecure Configurations, Insecure Defaults, Networking and Firewall, Observability, Resource Management, Secret Management, Supply-Chain, Structure and Semantics` |
 | `exclude_paths` | Exclude paths from scan | No | - | `./sample-dir-to-omit/*,sample-file.tf` |
-| `exclude_platforms` | Exclude results for the specified platforms, accepts a comma-separated list | No | - | Allowed values: `Ansible, AzureResourceManager, Buildah, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Knative, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform` |
-| `exclude_severities` | Exclude results for the specified severities, accepts a comma-separated list | No | - | Allowed values: `high, medium, low, info` |
-| `fail_on` | Which kind of results should return a non-zero exit code, accepts a comma-separated list of `<severity>=<value>` | No | `high=1,medium=1,low=1,info=1` | `"high=2,medium=50"` |
+| `exclude_platforms` | Exclude results for the specified platforms, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`<br>FCS CLI <v1.0.0: Also includes `Buildah, Knative` |
+| `exclude_severities` | Exclude results for the specified severities, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `critical, high, medium, informational`<br>FCS CLI <v1.0.0: `high, medium, low, info` |
+| `fail_on` | Which kind of results should return a non-zero exit code, accepts a comma-separated list of `<severity>=<value>` | No | FCS CLI v1.0.0+: `critical=1,high=1,medium=1,informational=1`<br>FCS CLI <v1.0.0: `high=1,medium=1,low=1,info=1` | `"high=2,medium=50"` |
 | `output_path` | Path to save the scan results | No | `./` | `./scan-results` |
 | `path` | Path to local file, directory or git repo to scan | No | - | `./my-local-dir, git::<git repo>, sample-file.tf` |
-| `platforms` | Include results for the specified platforms, accepts a comma-separated list | No | - | Allowed values: `Ansible, AzureResourceManager, Buildah, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Knative, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform` |
+| `platforms` | Include results for the specified platforms, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`<br>FCS CLI <v1.0.0: Also includes `Buildah, Knative` |
+| `policy_rule` | IaC cloud scanning policy-rule (FCS CLI v1.0.0+ only) | No | `local` | `local`, `default-iac-alert-rule` |
 | `project_owners` | Comma-separated list of project owners to notify (max 5) | No | - | `john@example.com,jane@example.com` |
 | `report_formats` | Formats in which reports are to be written, accepts a comma-separated list | No | `json` | Allowed values: `json, csv, junit, sarif` |
-| `severities` | Include results for the specified severities, accepts a comma-separated list | No | - | Allowed values: `high, medium, low, info` |
-| `timeout` | Timeout for the scan in seconds | No | `300` | `900` |
+| `severities` | Include results for the specified severities, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `critical, high, medium, informational`<br>FCS CLI <v1.0.0: `high, medium, low, info` |
+| `timeout` | Timeout for the scan in seconds | No | FCS CLI v1.0.0+: `500`<br>FCS CLI <v1.0.0: `300` | `900` |
 | `upload_results` | Upload scan results to the CrowdStrike Falcon Console | No | `false` | `true` |
 
 ## Outputs
@@ -94,6 +111,53 @@ To use this action in your workflow, add the following step:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```
 <!-- x-release-please-end -->
+
+### Using a specific FCS CLI version for compatibility with old severity levels
+<!-- x-release-please-start-version -->
+```yaml
+- name: Run FCS IaC Scan
+  uses: crowdstrike/fcs-action@v1.0.6
+  with:
+    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
+    falcon_region: 'us-2'
+    version: '0.47.1'  # Specifying an older FCS CLI version
+    path: './kubernetes'
+    severities: 'medium,low'  # Using severity levels from older FCS CLI versions
+  env:
+    FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+```
+<!-- x-release-please-end -->
+
+### Using latest FCS CLI version with updated severity levels
+<!-- x-release-please-start-version -->
+```yaml
+- name: Run FCS IaC Scan
+  uses: crowdstrike/fcs-action@v1.0.6
+  with:
+    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
+    falcon_region: 'us-2'
+    path: './kubernetes'
+    severities: 'critical,high,medium'  # Using severity levels from FCS CLI v1.0.0+
+  env:
+    FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+```
+<!-- x-release-please-end -->
+
+### Using the new policy rule parameter (FCS CLI v1.0.0+ only)
+<!-- x-release-please-start-version -->
+```yaml
+- name: Run FCS IaC Scan
+  uses: crowdstrike/fcs-action@v1.0.6
+  with:
+    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
+    falcon_region: 'us-2'
+    path: './kubernetes'
+    policy_rule: 'default-iac-alert-rule'  # New parameter in v1.0.0+
+  env:
+    FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+```
+<!-- x-release-please-end -->
+
 ### Upload SARIF report to GitHub Code scanning on non-zero exit code
 <!-- x-release-please-start-version -->
 ```yaml
@@ -116,6 +180,7 @@ To use this action in your workflow, add the following step:
       sarif_file: ./scan-results/*-scan-results.sarif
 ```
 <!-- x-release-please-end -->
+
 ### Scan with exclusions and severity filtering
 <!-- x-release-please-start-version -->
 ```yaml

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To use this action in your workflow, add the following step:
 ```
 <!-- x-release-please-end -->
 
-### Using latest FCS CLI version with severity levels
+### Specifying severity levels
 <!-- x-release-please-start-version -->
 ```yaml
 - name: Run FCS IaC Scan
@@ -196,10 +196,10 @@ You can also use configuration files to customize the scan parameters. For more 
 {
     "path": "./scan-dir",
     "fail-on": [
+        "critical=1",
         "high=1",
         "medium=1",
-        "low=1",
-        "info=1"
+        "informational=1"
     ],
     "output-path": "./results",
     "report-formats": [
@@ -209,9 +209,6 @@ You can also use configuration files to customize the scan parameters. For more 
     "timeout": 300
 }
 ```
-
-> [!NOTE]
-> If you're using a configuration file with FCS CLI v1.0.0+, make sure the severity levels in your configuration match the new format (`critical|high|medium|informational` instead of `high|medium|low|info`).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,18 @@ To use this action in your workflow, add the following step:
 <!-- x-release-please-end -->
 
 > [!IMPORTANT]
-> **FCS CLI Version Differences**
+> **Understanding Version Differences**
 >
-> The FCS CLI tool has significant changes between versions. If no version is specified, the latest version (currently v1.0.0) is used by default.
+> There are two different version numbers to be aware of:
 >
-> Key changes in v1.0.0:
+> 1. **GitHub Action Version** (`crowdstrike/fcs-action@v1.0.6`) - This is the version of the GitHub Action wrapper.
+> 2. **FCS CLI Version** (specified with the `version` parameter) - This is the version of the underlying scanning tool.
+>
+> **FCS CLI Version Changes**
+>
+> The underlying FCS CLI tool has significant changes between versions. If no `version` parameter is specified, the latest FCS CLI version (currently v1.0.0) is used by default.
+>
+> Key changes in FCS CLI v1.0.0:
 >
 > - **Severity levels**: Changed from `high|medium|low|info` to `critical|high|medium|informational`
 > - **Default fail-on values**: Changed from `high=1,medium=1,low=1,info=1` to `critical=1,high=1,medium=1,informational=1`
@@ -57,7 +64,7 @@ To use this action in your workflow, add the following step:
 > - **Default timeout**: Increased from 300 seconds to 500 seconds
 > - **Added new parameter**: `policy_rule` for specifying IaC cloud scanning policy-rule
 >
-> To use an older CLI version, specify the `version` parameter (e.g., `version: '0.47.1'`).
+> To use an older FCS CLI version, specify the `version` parameter (e.g., `version: '0.47.1'`).
 
 ## Environment Variables
 
@@ -71,7 +78,7 @@ To use this action in your workflow, add the following step:
 |-------|-------------|----------|---------|---------|
 | `falcon_client_id` | CrowdStrike API Client ID for authentication | **Yes** | - | `${{ vars.FALCON_CLIENT_ID }}` |
 | `falcon_region` | CrowdStrike API region | **Yes** | `us-1` | Allowed values: `us-1, us-2, eu-1, us-gov-1, us-gov-2` |
-| `version` | FCS CLI version to use | No | - | `0.47.1` |
+| `version` | **FCS CLI tool** version to use (_not the GitHub Action version_) | No | - | `0.47.1` |
 | `categories` | Include results for the specified categories, accepts a comma-separated list | No | - | `Access Control,Best Practices` |
 | `config` | Path to the scan configuration file | No | - | `./fcs-config.json` |
 | `disable_secrets_scan` | Disable scanning of secrets and passwords in target files | No | `false` | Allowed values: `true, false` |
@@ -83,7 +90,7 @@ To use this action in your workflow, add the following step:
 | `output_path` | Path to save the scan results | No | `./` | `./scan-results` |
 | `path` | Path to local file, directory or git repo to scan | No | - | `./my-local-dir, git::<git repo>, sample-file.tf` |
 | `platforms` | Include results for the specified platforms, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `Ansible, AzureResourceManager, CloudFormation, Crossplane, DockerCompose, Dockerfile, GoogleDeploymentManager, Kubernetes, OpenAPI, Pulumi, ServerlessFW, Terraform`<br>FCS CLI <v1.0.0: Also includes `Buildah, Knative` |
-| `policy_rule` | IaC cloud scanning policy-rule (FCS CLI v1.0.0+ only) | No | `local` | `local`, `default-iac-alert-rule` |
+| `policy_rule` | IaC cloud scanning policy-rule (_FCS CLI v1.0.0+ only_) | No | `local` | `local`, `default-iac-alert-rule` |
 | `project_owners` | Comma-separated list of project owners to notify (max 5) | No | - | `john@example.com,jane@example.com` |
 | `report_formats` | Formats in which reports are to be written, accepts a comma-separated list | No | `json` | Allowed values: `json, csv, junit, sarif` |
 | `severities` | Include results for the specified severities, accepts a comma-separated list | No | - | FCS CLI v1.0.0+: `critical, high, medium, informational`<br>FCS CLI <v1.0.0: `high, medium, low, info` |
@@ -120,7 +127,7 @@ To use this action in your workflow, add the following step:
   with:
     falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-2'
-    version: '0.47.1'  # Specifying an older FCS CLI version
+    version: '0.47.1'  # FCS CLI tool version
     path: './kubernetes'
     severities: 'medium,low'  # Using severity levels from older FCS CLI versions
   env:
@@ -136,6 +143,7 @@ To use this action in your workflow, add the following step:
   with:
     falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-2'
+    # No version specified, will use latest FCS CLI tool version (v1.0.0)
     path: './kubernetes'
     severities: 'critical,high,medium'  # Using severity levels from FCS CLI v1.0.0+
   env:
@@ -151,8 +159,9 @@ To use this action in your workflow, add the following step:
   with:
     falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-2'
+    # No version specified, will use latest FCS CLI tool version (v1.0.0)
     path: './kubernetes'
-    policy_rule: 'default-iac-alert-rule'  # New parameter in v1.0.0+
+    policy_rule: 'default-iac-alert-rule'  # Parameter only available in FCS CLI v1.0.0+
   env:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```
@@ -233,6 +242,9 @@ You can also use configuration files to customize the scan parameters. For more 
     "timeout": 300
 }
 ```
+
+> [!NOTE]
+> If you're using a configuration file with FCS CLI v1.0.0+, make sure the severity levels in your configuration match the new format (`critical|high|medium|informational` instead of `high|medium|low|info`).
 
 ## Support
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
   platforms:
     description: 'Include results for the specified platforms, accepts a comma-separated list (e.g Ansible,CloudFormation)'
     required: false
+  policy_rule:
+    description: 'IaC cloud scanning policy-rule (FCS CLI v1.0.0+ only). Use "local" for local rules, "default-iac-alert-rule" for cloud-based rules'
+    required: false
+    default: 'local'
   project_owners:
     description: 'Comma-separated list of project owners to notify (max 5)'
     required: false
@@ -101,6 +105,7 @@ runs:
         INPUT_OUTPUT_PATH: ${{ inputs.output_path }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_PLATFORMS: ${{ inputs.platforms }}
+        INPUT_POLICY_RULE: ${{ inputs.policy_rule }}
         INPUT_PROJECT_OWNERS: ${{ inputs.project_owners }}
         INPUT_REPORT_FORMATS: ${{ inputs.report_formats }}
         INPUT_SEVERITIES: ${{ inputs.severities }}

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
     description: 'Include results for the specified platforms, accepts a comma-separated list (e.g Ansible,CloudFormation)'
     required: false
   policy_rule:
-    description: 'IaC cloud scanning policy-rule (FCS CLI v1.0.0+ only). Use "local" for local rules, "default-iac-alert-rule" for cloud-based rules'
+    description: 'IaC cloud scanning policy-rule. Use "local" for local rules, "default-iac-alert-rule" for cloud-based rules'
     required: false
     default: 'local'
   project_owners:

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -106,6 +106,7 @@ set_parameters() {
         "FAIL_ON:fail-on"
         "OUTPUT_PATH:output-path"
         "PLATFORMS:platforms"
+        "POLICY_RULE:policy-rule"
         "PROJECT_OWNERS:project-owners"
         "REPORT_FORMATS:report-formats"
         "SEVERITIES:severities"


### PR DESCRIPTION
Closes #24 

With the latest release of FCS CLI v1.0.0 - a few breaking changes were made. This PR:
- Adds context to the differences between v1.0.0+ and <v1.0.0 in the documentation
- Added the new `policy_rule` options available for v1.0.0+

Will result in a new version 1.1.0
