### PR TITLE
allow user to provide bin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ To use this action in your workflow, add the following step:
 | `falcon_client_id` | CrowdStrike API Client ID | **Yes** | - | `${{ vars.FALCON_CLIENT_ID }}` |
 | `falcon_region` | CrowdStrike API region | **Yes** | **us-1**| **Allowed values**:</br>us-1</br>us-2</br>eu-1</br>us-gov-1</br>us-gov-2 |
 | `version` | FCS CLI tool version to use | No | uses the latest | `2.0.2` |
+| `bin_path` | FCS binary installation path | No | `$RUNNER_TEMP` | `./tmp` |
 | `scan_type` | Type of scan to perform | No | `iac` | **Allowed values**:</br>iac</br>image |
 
 ### Common Parameters

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To use this action in your workflow, add the following step:
 | `falcon_client_id` | CrowdStrike API Client ID | **Yes** | - | `${{ vars.FALCON_CLIENT_ID }}` |
 | `falcon_region` | CrowdStrike API region | **Yes** | **us-1**| **Allowed values**:</br>us-1</br>us-2</br>eu-1</br>us-gov-1</br>us-gov-2 |
 | `version` | FCS CLI tool version to use | No | uses the latest | `2.0.2` |
-| `bin_path` | FCS binary installation path | No | `$RUNNER_TEMP` | `./tmp` |
+| `bin_path` | FCS binary installation path | No | `$RUNNER_TEMP` | `/custom/bin` |
 | `scan_type` | Type of scan to perform | No | `iac` | **Allowed values**:</br>iac</br>image |
 
 ### Common Parameters

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
       run: python $GITHUB_ACTION_PATH/fcs_download.py
       shell: bash
       env:
-        INPUT_FALCON_BIN_PATH: ${{ inputs.bin_path }}
+        INPUT_BIN_PATH: ${{ inputs.bin_path }}
         INPUT_FALCON_CLIENT_ID: ${{ inputs.falcon_client_id }}
         INPUT_FALCON_REGION: ${{ inputs.falcon_region }}
         INPUT_VERSION: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: 'red'
 inputs:
   bin_path:
-    description: 'The location that Crowdstrike should use for the binary'
+    description: 'FCS binary installation path (defaults to $RUNNER_TEMP)'
     required: false
   falcon_client_id:
     description: 'CrowdStrike API Client ID for authentication'

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: 'shield'
   color: 'red'
 inputs:
+  bin_path:
+    description: 'The location that Crowdstrike should use for the binary'
+    required: false
   falcon_client_id:
     description: 'CrowdStrike API Client ID for authentication'
     required: true
@@ -150,6 +153,7 @@ runs:
       run: python $GITHUB_ACTION_PATH/fcs_download.py
       shell: bash
       env:
+        INPUT_FALCON_BIN_PATH: ${{ inputs.bin_path }}
         INPUT_FALCON_CLIENT_ID: ${{ inputs.falcon_client_id }}
         INPUT_FALCON_REGION: ${{ inputs.falcon_region }}
         INPUT_VERSION: ${{ inputs.version }}

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -88,7 +88,7 @@ convert_json_to_sarif() {
                 log "convert_json_to_sarif: Converting $json_file to $sarif_file"
 
                 # Use the Python converter
-                if python3 "$GITHUB_WORKSPACE/json_to_sarif_converter.py" "$json_file" "$sarif_file" 2>/dev/null; then
+                if python3 "$GITHUB_ACTION_PATH/json_to_sarif_converter.py" "$json_file" "$sarif_file" 2>/dev/null; then
                     ((success_count++))
                     log "convert_json_to_sarif: Successfully converted $json_file to $sarif_file"
                 else

--- a/fcs_download.py
+++ b/fcs_download.py
@@ -290,6 +290,7 @@ def main():
     print("CrowdStrike FCS download with falconpy")
     print("=" * 60)
     # Get inputs from environment (GitHub Actions sets these)
+    bin_path = os.getenv("INPUT_FALCON_BIN_PATH", "/opt/crowdstrike/bin")
     client_id = os.getenv("INPUT_FALCON_CLIENT_ID")
     client_secret = os.getenv(
         "FALCON_CLIENT_SECRET"
@@ -319,7 +320,6 @@ def main():
         print(f"ERROR: Failed to initialize FCS downloader: {e}")
         sys.exit(1)
     # Download FCS
-    bin_path = "/opt/crowdstrike/bin"
     fcs_binary_path = downloader.download_fcs(target_version=version, bin_path=bin_path)
     if fcs_binary_path:
         # Set GitHub Actions output
@@ -339,3 +339,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/fcs_download.py
+++ b/fcs_download.py
@@ -234,7 +234,7 @@ class FCSDownloader:
     def download_fcs(
         self,
         target_version: Optional[str] = None,
-        bin_path: str = "/opt/crowdstrike/bin",
+        bin_path: str = "/tmp",
     ) -> Optional[str]:
         """Main method to download FCS."""
         # Step 1: Detect platform
@@ -290,7 +290,7 @@ def main():
     print("CrowdStrike FCS download with falconpy")
     print("=" * 60)
     # Get inputs from environment (GitHub Actions sets these)
-    bin_path = os.getenv("INPUT_FALCON_BIN_PATH", "/opt/crowdstrike/bin")
+    bin_path = os.getenv("INPUT_FALCON_BIN_PATH", os.getenv("RUNNER_TEMP", "/tmp"))
     client_id = os.getenv("INPUT_FALCON_CLIENT_ID")
     client_secret = os.getenv(
         "FALCON_CLIENT_SECRET"

--- a/fcs_download.py
+++ b/fcs_download.py
@@ -234,7 +234,7 @@ class FCSDownloader:
     def download_fcs(
         self,
         target_version: Optional[str] = None,
-        bin_path: str = "/tmp",
+        bin_path: str = "/tmp/",
     ) -> Optional[str]:
         """Main method to download FCS."""
         # Step 1: Detect platform
@@ -290,7 +290,11 @@ def main():
     print("CrowdStrike FCS download with falconpy")
     print("=" * 60)
     # Get inputs from environment (GitHub Actions sets these)
-    bin_path = os.getenv("INPUT_FALCON_BIN_PATH", os.getenv("RUNNER_TEMP", "/tmp"))
+    bin_path = (
+        os.getenv("INPUT_BIN_PATH").strip()
+        or os.getenv("RUNNER_TEMP").strip()
+        or "/tmp/" # catch-all
+    )
     client_id = os.getenv("INPUT_FALCON_CLIENT_ID")
     client_secret = os.getenv(
         "FALCON_CLIENT_SECRET"
@@ -339,4 +343,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
provide the user the ability to specify the location for the binary as they may not have write access to /opt. still defaults to /opt/crowdstrike/bin