### PR TITLE
Shibachu patch 1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
+      if: ${{ inputs.bypass_pythonsetup  == 'false' }} 
       uses: actions/setup-python@v4
       with:
         python-version: '3.12'


### PR DESCRIPTION
Option to bypass python setup. To help in a situation where action/setup-python doesn't work.  #45 