### PR TITLE
fix: enable GitHub severity levels for SARIF files

### DIFF
--- a/json_to_sarif_converter.py
+++ b/json_to_sarif_converter.py
@@ -263,7 +263,7 @@ def convert_image_vulnerabilities(scan_data: Dict[str, Any], run: Dict[str, Any]
             "properties": {
                 "tags": ["vulnerability", "security"],
                 "precision": "high",
-                "security-severity": base_score
+                "security-severity": str(base_score)
             }
         })
 


### PR DESCRIPTION
This PR is to add the "security-severity" property to each element of the "rules" list in the SARIF (json) file.

As documented [here](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#reportingdescriptor-object), GitHub uses "properties.security-severity" to include the severity ("Critical", "High", "Medium", "Low") based on the "security-severity" value.

This is a better experience for developers than seeing a severity level of "Error", "Warning", or "Note" (the current behavior). This is also better for AppSec reporting as it is consistent with severity levels of other tools.

Current state:
<img width="563" height="335" alt="image" src="https://github.com/user-attachments/assets/2c3c52f9-7071-4175-b445-765ce0d1b717" />

Future state:
<img width="537" height="389" alt="image" src="https://github.com/user-attachments/assets/dac5f78c-ede7-4e57-a3f1-748d0e13f6b0" />
