### PR TITLE
feat: add project_name parameter for IaC scans

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -77,6 +77,7 @@ jobs:
           path: tests/
           output_path: iac-scan-results/
           report_formats: sarif
+          project_name: fcs-action-test-project
         env:
           FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ To use this action in your workflow, add the following step:
 - name: Run FCS IaC Scan
   uses: crowdstrike/fcs-action@v2.0.3
   with:
-    falcon_client_id: 'abcdefghijk123456789'
+    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-1'
     path: './my-iac-directory'
+    project_name: 'my-awesome-project'
   env:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```
@@ -93,9 +94,9 @@ To use this action in your workflow, add the following step:
 | `report_formats` | List of output formats for reports | No | `json` | **Allowed values**:</br>json, csv, junit, sarif |
 | `config` | Path to configuration file | No | - | `./fcs-config.json` |
 | `policy_rule` | IaC scanning policy rule | No | `local` | **Allowed values**:</br>local</br>default-iac-alert-rule |
-| `timeout` | Scan timeout in seconds | No | `500` | `900` |
 | `disable_secrets_scan` | Disable secrets scanning | No | `false` | **Allowed values**:</br>true</br>false |
 | `project_owners` | Project owners to notify (max 5) | No | - | `john@example.com,jane@example.com` |
+| `project_name` | Name of the project for identification in Falcon console | No | - | `my-awesome-project` |
 
 #### Filtering & Categorization
 
@@ -272,6 +273,23 @@ fail_on: 'critical=1,high=1,medium=1,informational=1'
 ```
 <!-- x-release-please-end -->
 
+### IaC scan with project identification
+<!-- x-release-please-start-version -->
+```yaml
+- name: Run FCS IaC Scan with Project Name
+  uses: crowdstrike/fcs-action@v2.0.3
+  with:
+    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
+    falcon_region: 'us-1'
+    path: './infrastructure'
+    project_name: 'payment-service-infrastructure'
+    severities: 'critical,high'
+    report_formats: 'sarif'
+    output_path: './security-scan-results/'
+  env:
+    FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+```
+<!-- x-release-please-end -->
 
 ### Upload SARIF report to GitHub Code scanning on non-zero exit code
 <!-- x-release-please-start-version -->

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,9 @@ inputs:
   project_owners:
     description: 'Comma-separated list of project owners to notify (max 5)'
     required: false
+  project_name:
+    description: 'Name of the project for identification in Falcon console'
+    required: false
   report_formats:
     description: 'Comma-separated list of formats in which reports are to be written (e.g. json,sarif)'
     required: false
@@ -180,6 +183,7 @@ runs:
         INPUT_PLATFORMS: ${{ inputs.platforms }}
         INPUT_POLICY_RULE: ${{ inputs.policy_rule }}
         INPUT_PROJECT_OWNERS: ${{ inputs.project_owners }}
+        INPUT_PROJECT_NAME: ${{ inputs.project_name }}
         INPUT_REPORT_FORMATS: ${{ inputs.report_formats }}
         INPUT_SEVERITIES: ${{ inputs.severities }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -257,6 +257,7 @@ set_parameters() {
             "PLATFORMS:platforms"
             "POLICY_RULE:policy-rule"
             "PROJECT_OWNERS:project-owners"
+            "PROJECT_NAME:project-name"
             "REPORT_FORMATS:report-formats"
             "SEVERITIES:severities"
             "TIMEOUT:timeout"


### PR DESCRIPTION
## Summary

Adds optional `project_name` input parameter to enable custom project identification in the Falcon console, solving the multi-repository identification problem described in issue #35.

### Changes Made

- **Added `project_name` input parameter** to `action.yml` (IaC scans only)
- **Updated `fcs-scan.sh`** to process `--project-name` CLI flag for IaC mode
- **Enhanced documentation** with comprehensive examples in README.md
- **Added test coverage** in workflow for the new parameter
- **Fixed README structure** and consistency issues

### Key Features

- **IaC Only**: The `--project-name` flag is only supported by the FCS CLI for IaC scans, not image scans
- **Optional**: Fully backward compatible - existing workflows continue to work unchanged
- **Well Documented**: Includes clear examples and proper parameter organization
- **Tested**: Added to CI workflow to ensure proper functionality

### Usage Example

```yaml
- name: Run FCS IaC Scan with Project Name
  uses: crowdstrike/fcs-action@main
  with:
    falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
    falcon_region: 'us-1'
    path: './infrastructure'
    project_name: 'payment-service-infrastructure'
  env:
    FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
```

Closes #35