### PR TITLE
fix: support 2.3.0 multi-arch image scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Create a GitHub secret in your repository to store the CrowdStrike API Client se
 
 **Scan all architectures (default):**
 
+<!-- x-release-please-start-version -->
 ```yaml
 - name: Scan All Architectures
   uses: crowdstrike/fcs-action@v4.0.0
@@ -70,9 +71,11 @@ Create a GitHub secret in your repository to store the CrowdStrike API Client se
     image: nginx:latest
     # Omit platform parameter to scan all architectures
 ```
+<!-- x-release-please-end -->
 
 **Scan specific architectures only:**
 
+<!-- x-release-please-start-version -->
 ```yaml
 - name: Scan Specific Architectures
   uses: crowdstrike/fcs-action@v4.0.0
@@ -81,9 +84,11 @@ Create a GitHub secret in your repository to store the CrowdStrike API Client se
     image: nginx:latest
     platform: linux/amd64,linux/arm64  # New: Comma-separated list
 ```
+<!-- x-release-please-end -->
 
 **Scan single architecture (previous behavior):**
 
+<!-- x-release-please-start-version -->
 ```yaml
 - name: Scan Single Architecture
   uses: crowdstrike/fcs-action@v4.0.0
@@ -92,6 +97,7 @@ Create a GitHub secret in your repository to store the CrowdStrike API Client se
     image: nginx:latest
     platform: linux/amd64  # Only scan amd64
 ```
+<!-- x-release-please-end -->
 
 ## Important Changes in FCS CLI 2.2.0
 
@@ -209,7 +215,7 @@ To use this action in your workflow, add the following step:
 | `output_path` | File path to save scan results.</br>**NOTE: must be a file path ending with .json, .sarif, or .cdx.json**</br>Omit to use CLI default: `~/.crowdstrike/image_assessment/reports/` | No | (uses CLI default) | `./scan-results.json` |
 | `report_formats` | A **single** output format for generated report | No | `json` | **Allowed values**:</br>**Image**: json, sarif, cyclonedx-json |
 | `socket` | Custom container engine socket | No | - | `unix:///var/run/docker.sock` |
-| `platform` | Target platform (os/arch/variant) | No | `linux/amd64` | `linux/amd64`</br>`linux/arm64`</br>`windows/amd64` |
+| `platform` | Target platform (os/arch/variant) | No | - | `linux/amd64`</br>`linux/arm64`</br>`windows/amd64` |
 | `temp_dir` | Custom temp directory | No | - | `/local/tmp` |
 
 #### Scan Mode Options

--- a/README.md
+++ b/README.md
@@ -43,6 +43,56 @@ Create a GitHub secret in your repository to store the CrowdStrike API Client se
 | **`>= 1.0.0`** and **`< 2.0.0`**  | **`>= 1.1.0`** and **`< 2.0.0`** |
 | **`< 1.0.0`**       | **`< 1.1.0`**          |
 
+## What's New in FCS CLI 2.3.x
+
+> [!NOTE]
+> FCS CLI version 2.3.x introduces multi-architecture image scanning support. The FCS Action automatically handles these changes - no workflow modifications required.
+
+### Multi-Architecture Image Scanning
+
+**What's New:** When scanning multi-architecture (multi-arch) images, the FCS CLI now scans **all architecture variants by default** instead of only the host architecture.
+
+**What This Means for Your Workflows:**
+
+- **Multiple Report Files**: If you scan a multi-arch image (e.g., `nginx:latest`), you'll receive separate reports for each architecture (linux/amd64, linux/arm64, etc.)
+- **Exit Codes**: The action returns a non-zero exit code if ANY architecture variant fails your assessment criteria
+- **No Changes Needed**: The action automatically discovers and processes all generated reports
+
+### Controlling Which Architectures to Scan
+
+**Scan all architectures (default):**
+
+```yaml
+- name: Scan All Architectures
+  uses: crowdstrike/fcs-action@v4.0.0
+  with:
+    scan_type: image
+    image: nginx:latest
+    # Omit platform parameter to scan all architectures
+```
+
+**Scan specific architectures only:**
+
+```yaml
+- name: Scan Specific Architectures
+  uses: crowdstrike/fcs-action@v4.0.0
+  with:
+    scan_type: image
+    image: nginx:latest
+    platform: linux/amd64,linux/arm64  # New: Comma-separated list
+```
+
+**Scan single architecture (previous behavior):**
+
+```yaml
+- name: Scan Single Architecture
+  uses: crowdstrike/fcs-action@v4.0.0
+  with:
+    scan_type: image
+    image: nginx:latest
+    platform: linux/amd64  # Only scan amd64
+```
+
 ## Important Changes in FCS CLI 2.2.0
 
 > [!IMPORTANT]
@@ -125,7 +175,7 @@ To use this action in your workflow, add the following step:
 | Input | Description | Required | Default | Example/Values |
 | ----- | ----------- | -------- | ------- | -------------- |
 | `path` | Path to scan (file/dir/git repo) | No | - | `./dir`</br>`git::repo`</br>`file.tf` |
-| `output_path` | Path to save scan results</br>**NOTE: Must be a directory when using multiple report formats** (FCS CLI 2.2.0+) | No | `./` | `./scan-results` |
+| `output_path` | Path to save scan results</br>**NOTE: Must be a directory when using multiple report formats** (FCS CLI 2.2.0+) | No | (uses CLI default) | `./scan-results/` |
 | `report_formats` | List of output formats for reports | No | `json` | **Allowed values**:</br>json, csv, junit, sarif |
 | `config` | Path to configuration file | No | - | `./fcs-config.json` |
 | `policy_rule` | IaC scanning policy rule | No | `local` | **Allowed values**:</br>local</br>default-iac-alert-rule |
@@ -156,7 +206,7 @@ To use this action in your workflow, add the following step:
 | Input | Description | Required | Default | Example/Values |
 | ----- | ----------- | -------- | ------- | -------------- |
 | `image` | Container image to scan | **Yes*** | - | `nginx:latest`</br>`quay.io/org/app:v1.0` |
-| `output_path` | File path to save scan results.</br>**NOTE: must be a file, not a directory.** | No |  | `./scan-results.json` |
+| `output_path` | File path to save scan results.</br>**NOTE: must be a file path ending with .json, .sarif, or .cdx.json**</br>Omit to use CLI default: `~/.crowdstrike/image_assessment/reports/` | No | (uses CLI default) | `./scan-results.json` |
 | `report_formats` | A **single** output format for generated report | No | `json` | **Allowed values**:</br>**Image**: json, sarif, cyclonedx-json |
 | `socket` | Custom container engine socket | No | - | `unix:///var/run/docker.sock` |
 | `platform` | Target platform (os/arch/variant) | No | `linux/amd64` | `linux/amd64`</br>`linux/arm64`</br>`windows/amd64` |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To use this action in your workflow, add the following step:
 | `output_path` | File path to save scan results.</br>**NOTE: must be a file path ending with .json, .sarif, or .cdx.json**</br>Omit to use CLI default: `~/.crowdstrike/image_assessment/reports/` | No | (uses CLI default) | `./scan-results.json` |
 | `report_formats` | A **single** output format for generated report | No | `json` | **Allowed values**:</br>**Image**: json, sarif, cyclonedx-json |
 | `socket` | Custom container engine socket | No | - | `unix:///var/run/docker.sock` |
-| `platform` | Target platform (os/arch/variant) | No | - | `linux/amd64`</br>`linux/arm64`</br>`windows/amd64` |
+| `platform` | Target platform(s). Single value or comma-separated list (FCS CLI >= 2.3.0) | No | - | `linux/amd64`</br>`linux/amd64,linux/arm64`</br>`windows/amd64` |
 | `temp_dir` | Custom temp directory | No | - | `/local/tmp` |
 
 #### Scan Mode Options

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ inputs:
     description: 'Custom socket path for container engine (e.g., unix:///var/run/docker.sock)'
     required: false
   platform:
-    description: 'Target platform for multi-platform images in OS/ARCH[/VARIANT] format (e.g., linux/amd64)'
+    description: 'Target platform(s) for multi-platform images. Single value or comma-separated list in OS/ARCH format (e.g., linux/amd64 or linux/amd64,linux/arm64)'
     required: false
   vulnerability_only:
     description: 'Image scan for vulnerabilities only'

--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,8 @@ inputs:
     description: 'Comma-separated list of which kind of results should return an exit code different from 0'
     required: false
   output_path:
-    description: 'Path to save the scan results'
+    description: 'Path to save the scan results. For IaC: file or directory path. For image scans: must be a file path with .json, .sarif, or .cdx.json extension, or omit to use CLI defaults'
     required: false
-    default: "./"
   path:
     description: 'Path to local file, local directory or git repo to scan (e.g. ./my-local-dir, git::<git repo>, sample-file.tf)'
     required: false

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -40,70 +40,56 @@ prepare_report_formats_for_cli() {
 }
 
 convert_json_to_sarif() {
-    local output_path
+    local all_json_files=""
 
-    if [ "$INPUT_SCAN_TYPE" = "iac" ]; then
-        output_path="${INPUT_OUTPUT_PATH}"
-    elif [ "$INPUT_SCAN_TYPE" = "image" ] && [ "$INPUT_OUTPUT_PATH" ]; then
-        output_path="${INPUT_OUTPUT_PATH}"
-    else
-        output_path="$HOME/.crowdstrike/image_assessment/reports/"
-    fi
+    # Parse FCS CLI output to find generated files
+    if [[ -f "$FCS_CLI_OUTPUT_FILE" ]]; then
+        log "convert_json_to_sarif: Parsing CLI output from $FCS_CLI_OUTPUT_FILE"
 
-    log "convert_json_to_sarif: Looking for JSON files in: $output_path"
+        # Extract file paths from "Results saved to file: <path>" lines
+        all_json_files=$(grep "Results saved to file:" "$FCS_CLI_OUTPUT_FILE" | \
+                        sed 's/.*Results saved to file: //' | \
+                        grep '\.json$' | \
+                        sort)
 
-    # Look for all .json files - handle both file and directory paths
-    local all_json_files
-    if [[ -f "$output_path" ]]; then
-        # Handle single file case (can be .json or .sarif containing JSON content)
-        all_json_files="$output_path"
-        if [[ "$output_path" == *.sarif ]]; then
-            log "convert_json_to_sarif: Processing file with .sarif extension containing JSON: $output_path"
+        if [[ -n "$all_json_files" ]]; then
+            log "convert_json_to_sarif: Found JSON files from CLI output"
         else
-            log "convert_json_to_sarif: Processing single JSON file: $output_path"
+            log "convert_json_to_sarif: No 'Results saved to file' messages found in CLI output" "WARN"
         fi
-    elif [[ -d "$output_path" ]]; then
-        # Handle directory case
-        all_json_files=$(find "$output_path" -name "*.json" 2>/dev/null)
-        log "convert_json_to_sarif: Searching directory for JSON files"
     else
-        # For image scans, try adjusting .sarif to .json if the original path doesn't exist
-        if [[ "$INPUT_SCAN_TYPE" = "image" && "$output_path" == *.sarif ]]; then
-            local json_path="${output_path%.sarif}.json"
-            if [[ -f "$json_path" ]]; then
-                output_path="$json_path"
-                all_json_files="$output_path"
-                log "convert_json_to_sarif: Found JSON file at adjusted path: $output_path"
-            else
-                all_json_files=""
-                log "convert_json_to_sarif: Neither original nor adjusted path exists: $output_path" "WARN"
-            fi
+        log "convert_json_to_sarif: CLI output file not found, falling back to path-based discovery" "WARN"
+
+        # Fallback to path-based discovery if output file not available
+        local output_path
+        if [ "$INPUT_SCAN_TYPE" = "iac" ]; then
+            output_path="${INPUT_OUTPUT_PATH}"
+        elif [ "$INPUT_SCAN_TYPE" = "image" ] && [ "$INPUT_OUTPUT_PATH" ]; then
+            output_path="${INPUT_OUTPUT_PATH}"
         else
-            # Path doesn't exist or is not a file/directory
-            all_json_files=""
-            log "convert_json_to_sarif: Path does not exist or is not a file/directory: $output_path" "WARN"
+            output_path="$HOME/.crowdstrike/image_assessment/reports/"
+        fi
+
+        # Use directory search as fallback
+        if [[ -d "$output_path" ]]; then
+            all_json_files=$(find "$output_path" -name "*.json" 2>/dev/null | sort)
+            log "convert_json_to_sarif: Using fallback directory search in $output_path"
+        else
+            log "convert_json_to_sarif: Fallback failed - path not a directory: $output_path" "WARN"
         fi
     fi
 
     if [[ -n "$all_json_files" ]]; then
-        log "convert_json_to_sarif: Found JSON files: $all_json_files"
+        log "convert_json_to_sarif: Found JSON files: $(echo "$all_json_files" | tr '\n' ' ')"
         local success_count=0
         local total_count=0
 
         while IFS= read -r json_file; do
-            if [[ -n "$json_file" ]]; then
+            if [[ -n "$json_file" && -f "$json_file" ]]; then
                 ((total_count++))
 
-                # Generate SARIF filename - handle both .json and .sarif extensions
-                local sarif_file
-                if [[ "$json_file" == *.sarif ]]; then
-                    # File already has .sarif extension (contains JSON content)
-                    sarif_file="$json_file"
-                    log "convert_json_to_sarif: File already has .sarif extension, will overwrite with SARIF content: $sarif_file"
-                else
-                    # Standard case: .json extension becomes .sarif
-                    sarif_file="${json_file%.json}.sarif"
-                fi
+                # Generate SARIF filename
+                local sarif_file="${json_file%.json}.sarif"
 
                 log "convert_json_to_sarif: Converting $json_file to $sarif_file"
 
@@ -119,7 +105,12 @@ convert_json_to_sarif() {
 
         log "convert_json_to_sarif: Successfully converted $success_count out of $total_count JSON files to SARIF"
     else
-        log "convert_json_to_sarif: No JSON files found in $output_path" "WARN"
+        log "convert_json_to_sarif: No JSON files found" "WARN"
+    fi
+
+    # Cleanup temp file
+    if [[ -f "$FCS_CLI_OUTPUT_FILE" ]]; then
+        rm -f "$FCS_CLI_OUTPUT_FILE"
     fi
 }
 
@@ -410,6 +401,7 @@ set_parameters() {
 execute_fcs_cli() {
     local args="$1"
     local scan_type="${INPUT_SCAN_TYPE:-iac}"
+    local output_file="/tmp/fcs_cli_output_$$.txt"
 
     cd "$GITHUB_WORKSPACE" || die "Failed to change directory to $GITHUB_WORKSPACE"
 
@@ -417,16 +409,19 @@ execute_fcs_cli() {
 
     if [[ "$scan_type" == "iac" ]]; then
         # shellcheck disable=SC2086
-        $FCS_CLI_BIN scan iac $args
+        $FCS_CLI_BIN scan iac $args 2>&1 | tee "$output_file"
     elif [[ "$scan_type" == "image" ]]; then
         # shellcheck disable=SC2086
-        $FCS_CLI_BIN scan image $INPUT_IMAGE $args
+        $FCS_CLI_BIN scan image $INPUT_IMAGE $args 2>&1 | tee "$output_file"
     else
         die "Invalid scan_type '$scan_type'. Must be 'iac' or 'image'."
     fi
 
-    local exit_code=$?
+    local exit_code=${PIPESTATUS[0]}
     echo "exit-code=$exit_code" >> "$GITHUB_OUTPUT"
+
+    # Export output file path for convert_json_to_sarif to use
+    export FCS_CLI_OUTPUT_FILE="$output_file"
 }
 
 main() {

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -58,25 +58,7 @@ convert_json_to_sarif() {
             log "convert_json_to_sarif: No 'Results saved to file' messages found in CLI output" "WARN"
         fi
     else
-        log "convert_json_to_sarif: CLI output file not found, falling back to path-based discovery" "WARN"
-
-        # Fallback to path-based discovery if output file not available
-        local output_path
-        if [ "$INPUT_SCAN_TYPE" = "iac" ]; then
-            output_path="${INPUT_OUTPUT_PATH}"
-        elif [ "$INPUT_SCAN_TYPE" = "image" ] && [ "$INPUT_OUTPUT_PATH" ]; then
-            output_path="${INPUT_OUTPUT_PATH}"
-        else
-            output_path="$HOME/.crowdstrike/image_assessment/reports/"
-        fi
-
-        # Use directory search as fallback
-        if [[ -d "$output_path" ]]; then
-            all_json_files=$(find "$output_path" -name "*.json" 2>/dev/null | sort)
-            log "convert_json_to_sarif: Using fallback directory search in $output_path"
-        else
-            log "convert_json_to_sarif: Fallback failed - path not a directory: $output_path" "WARN"
-        fi
+        log "convert_json_to_sarif: CLI output file not found at $FCS_CLI_OUTPUT_FILE" "WARN"
     fi
 
     if [[ -n "$all_json_files" ]]; then

--- a/tests/README.md
+++ b/tests/README.md
@@ -195,7 +195,7 @@ The action continues to support IaC scanning with the same parameters as before:
 
 - `image` - Container image to scan (required for image scanning)
 - `socket` - Custom container engine socket path
-- `platform` - Target platform (e.g., linux/amd64, linux/arm64)
+- `platform` - Target platform(s), single value or comma-separated list (e.g., `linux/amd64` or `linux/amd64,linux/arm64`)
 - `vulnerability_only` - Scan for vulnerabilities only
 - `sbom_only` - Generate SBOM only
 - `minimum_score` - Minimum CVSS score threshold (0.0-10.0)
@@ -254,7 +254,7 @@ These images are chosen to provide a variety of vulnerability profiles for testi
 ### Common Issues
 
 1. **Missing image parameter**: Ensure `image` is specified when `scan_type` is `image`
-2. **Platform issues**: Specify `platform` for multi-arch images if needed
+2. **Platform issues**: Specify `platform` for multi-arch images if needed (comma-separated list supported with FCS CLI >= 2.3.0)
 3. **Output directory**: Ensure `output_path` directory exists or can be created
 4. **Report formats**: Use valid format names (json, sarif, cyclonedx-json)
 

--- a/tests/test-image-scan.sh
+++ b/tests/test-image-scan.sh
@@ -261,6 +261,71 @@ EOF
     echo
 }
 
+# ============================================================
+# SARIF Discovery Tests
+# Tests for convert_json_to_sarif file discovery logic
+# ============================================================
+
+# Helper: create minimal JSON files that mimic FCS CLI output
+create_mock_json() {
+    local path="$1"
+    mkdir -p "$(dirname "$path")"
+    echo '{"runs":[{"results":[]}]}' > "$path"
+}
+
+# Test the primary path: parsing "Results saved to file:" from CLI output
+test_sarif_discovery_primary_path() {
+    local test_name="$1"
+    local expected_count="$2"
+    local cli_output_content="$3"
+    shift 3
+    local json_files=("$@")
+
+    log "Testing SARIF discovery: $test_name"
+
+    local test_dir="/tmp/sarif_discovery_test_$$"
+    rm -rf "$test_dir"
+    mkdir -p "$test_dir"
+
+    # Create the mock JSON files on disk
+    for f in "${json_files[@]}"; do
+        create_mock_json "$f"
+    done
+
+    # Write mock CLI output
+    local cli_output_file="$test_dir/cli_output.txt"
+    echo "$cli_output_content" > "$cli_output_file"
+
+    # Run the discovery logic (primary path)
+    local all_json_files
+    all_json_files=$(grep "Results saved to file:" "$cli_output_file" | \
+                    sed 's/.*Results saved to file: //' | \
+                    grep '\.json$' | \
+                    sort)
+
+    local actual_count=0
+    if [[ -n "$all_json_files" ]]; then
+        while IFS= read -r json_file; do
+            if [[ -n "$json_file" && -f "$json_file" ]]; then
+                actual_count=$((actual_count + 1))
+            fi
+        done <<< "$all_json_files"
+    fi
+
+    if [[ "$actual_count" -eq "$expected_count" ]]; then
+        echo -e "  ${GREEN}✓${NC} Primary path discovered $actual_count file(s) as expected"
+    else
+        error "Primary path expected $expected_count file(s), got $actual_count"
+        error "CLI output content: $cli_output_content"
+        error "Discovered files: $all_json_files"
+        rm -rf "$test_dir"
+        return 1
+    fi
+
+    rm -rf "$test_dir"
+    echo
+}
+
 main() {
     log "Starting FCS Image Scan Tests"
     echo
@@ -343,6 +408,55 @@ main() {
         "false" \
         "INPUT_SCAN_TYPE=invalid"
     
+    # ============================================================
+    # SARIF Discovery: Primary Path Tests
+    # ============================================================
+
+    local sarif_test_dir="/tmp/sarif_discovery_test_$$"
+
+    # Test 12: Single JSON file from CLI output
+    create_mock_json "$sarif_test_dir/results.json"
+    test_sarif_discovery_primary_path \
+        "Single JSON file from CLI output" \
+        1 \
+        "Scanning image nginx:latest...
+Results saved to file: $sarif_test_dir/results.json
+Scan complete." \
+        "$sarif_test_dir/results.json"
+
+    # Test 13: Multi-arch JSON files from CLI output
+    create_mock_json "$sarif_test_dir/multi/results_linux_amd64.json"
+    create_mock_json "$sarif_test_dir/multi/results_linux_arm64.json"
+    test_sarif_discovery_primary_path \
+        "Multi-arch JSON files from CLI output" \
+        2 \
+        "Scanning image nginx:latest for linux/amd64...
+Results saved to file: $sarif_test_dir/multi/results_linux_amd64.json
+Scanning image nginx:latest for linux/arm64...
+Results saved to file: $sarif_test_dir/multi/results_linux_arm64.json
+Scan complete." \
+        "$sarif_test_dir/multi/results_linux_amd64.json" \
+        "$sarif_test_dir/multi/results_linux_arm64.json"
+
+    # Test 14: CLI output with non-JSON files mixed in (should only find .json)
+    create_mock_json "$sarif_test_dir/mixed/results.json"
+    test_sarif_discovery_primary_path \
+        "Filters non-JSON files from CLI output" \
+        1 \
+        "Results saved to file: $sarif_test_dir/mixed/results.json
+Results saved to file: $sarif_test_dir/mixed/results.sarif
+Results saved to file: $sarif_test_dir/mixed/results.cdx.xml" \
+        "$sarif_test_dir/mixed/results.json"
+
+    # Test 15: CLI output with no "Results saved to file:" lines
+    test_sarif_discovery_primary_path \
+        "No results lines in CLI output" \
+        0 \
+        "Scanning image nginx:latest...
+Scan complete. No issues found."
+
+    rm -rf "$sarif_test_dir"
+
     log "All tests completed successfully!"
     log "Image scanning functionality is working correctly."
     


### PR DESCRIPTION
  ## FCS CLI 2.3.x Multi-Architecture Support                                                                                                                                                                        
                                                        
  ### Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                     
  - **Auto-discover output files**: Parse FCS CLI output for "Results saved to file:" messages instead of guessing file patterns
  - **Multi-arch support**: Automatically handle multiple report files from multi-arch image scans
  - **SARIF conversion**: Convert all architecture variants to SARIF when requested
  - **Fix output_path default**: Remove `"./"` default that broke image scans; allow CLI defaults when omitted

  ### Technical Details

  - Modified `execute_fcs_cli()` to capture CLI output using `tee` while preserving exit codes
  - Rewrote `convert_json_to_sarif()` to parse CLI output instead of using file pattern matching
  - Updated `action.yml` to remove problematic default and improve description
  - Added comprehensive documentation for FCS CLI 2.3.x multi-arch scanning