### PR TITLE
fix: image scans failing with 400 for gov regions 

### DIFF
--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -274,6 +274,7 @@ set_parameters() {
     elif [[ "$scan_type" == "image" ]]; then
         # Image-specific parameters
         local input_params=(
+            "FALCON_REGION:falcon-region"
             "SOCKET:socket"
             "PLATFORM:platform"
             "OUTPUT_PATH:output"


### PR DESCRIPTION
 Issue:
--falcon-region was only passed to the FCS CLI when upload_results: true. IaC scans can run locally without it, but image scanning always requires an authenticated API call to fetch vulnerability data. Without the flag, the CLI defaulted to the us-1 endpoint, causing a 400 for us-gov-1 (and presumably us-gov-2) customers.
                                                                                                                                                                                                       
 Fix:
 adds --falcon-region to the unconditional image scan params so it's always passed regardless of upload_results.