### PR TITLE
feat!: support fcs cli release 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,35 @@ Create a GitHub secret in your repository to store the CrowdStrike API Client se
 | **`>= 1.0.0`** and **`< 2.0.0`**  | **`>= 1.1.0`** and **`< 2.0.0`** |
 | **`< 1.0.0`**       | **`< 1.1.0`**          |
 
+## What's New in FCS CLI 4.0.x
+
+> [!IMPORTANT]
+> FCS CLI 4.0.x changes how cloud-based IaC rules are applied and deprecates the `policy_rule` input.
+
+### Cloud Rules Now Applied by Default (IaC)
+
+**What Changed:** Cloud-based custom rules are now applied automatically on every IaC scan. The `policy_rule` input is **deprecated and ignored**.
+
+**Migration Required:**
+- **Before:** `policy_rule: 'default-iac-alert-rule'` to enable cloud rules
+- **After:** Cloud rules are on by default — remove `policy_rule` from your workflow
+- **To disable cloud rules:** Use the new `disable_custom_rules: true` input instead of `policy_rule: 'local'`
+
+### New Inputs (FCS CLI 4.0.x)
+
+| Input | Scan Type | Description |
+|---|---|---|
+| `disable_custom_rules` | IaC | Disable cloud-based rules; scan with local rules only. Replaces `policy_rule: local` |
+| `exclude_gitignore` | IaC | Disable automatic exclusion of paths listed in `.gitignore` |
+| `max_file_size` | IaC | Maximum file size in MB to scan (default 100) |
+| `module_cache` | IaC | Cache downloaded Terraform modules to disk across scans |
+| `scan_only` | Image | Run scan without generating report output |
+| `falcon_token` | Both | Bearer token for Falcon API, skips OAuth2 authentication |
+| `verbose` | Both | Enable verbose output |
+| `profile` | Both | Named profile from FCS CLI configuration |
+
+---
+
 ## What's New in FCS CLI 2.3.x
 
 > [!NOTE]
@@ -174,6 +203,9 @@ To use this action in your workflow, add the following step:
 | ----- | ----------- | -------- | ------- | -------------- |
 | `timeout` | Timeout for scan in seconds | No | `300` | `600` |
 | `upload_results` | Upload to Falcon Console | No | `false` | **Allowed values**:</br>true</br>false |
+| `verbose` | Enable verbose output | No | `false` | **Allowed values**:</br>true</br>false |
+| `profile` | Named profile from FCS CLI configuration | No | `default` | `production` |
+| `falcon_token` | Bearer token for Falcon API calls, skips OAuth2 | No | - | `BEARER <token>` |
 
 <details>
 <summary><strong>🛠️ IaC Scanning Parameters</strong> (Click to expand)</summary>
@@ -184,7 +216,11 @@ To use this action in your workflow, add the following step:
 | `output_path` | Path to save scan results</br>**NOTE: Must be a directory when using multiple report formats** (FCS CLI 2.2.0+) | No | (uses CLI default) | `./scan-results/` |
 | `report_formats` | List of output formats for reports | No | `json` | **Allowed values**:</br>json, csv, junit, sarif |
 | `config` | Path to configuration file | No | - | `./fcs-config.json` |
-| `policy_rule` | IaC scanning policy rule | No | `local` | **Allowed values**:</br>local</br>default-iac-alert-rule |
+| `policy_rule` | **(Deprecated, ignored as of FCS CLI 4.0.x)** Cloud rules are now applied by default. Use `disable_custom_rules` to opt out. | No | - | - |
+| `disable_custom_rules` | Disable cloud-based rules; scan with local rules only (FCS CLI 4.0.x+) | No | `false` | **Allowed values**:</br>true</br>false |
+| `exclude_gitignore` | Disable automatic exclusion of paths in `.gitignore` (FCS CLI 4.0.x+) | No | `false` | **Allowed values**:</br>true</br>false |
+| `max_file_size` | Maximum file size in MB for scanning (FCS CLI 4.0.x+) | No | `100` | `50` |
+| `module_cache` | Cache downloaded Terraform modules across scans (FCS CLI 4.0.x+) | No | `false` | **Allowed values**:</br>true</br>false |
 | `disable_secrets_scan` | Disable secrets scanning | No | `false` | **Allowed values**:</br>true</br>false |
 | `project_owners` | Project owners to notify (max 5) | No | - | `john@example.com,jane@example.com` |
 | `project_name` | Name of the project for identification in Falcon console | No | - | `my-awesome-project` |
@@ -224,6 +260,7 @@ To use this action in your workflow, add the following step:
 | ----- | ----------- | -------- | ------- | -------------- |
 | `vulnerability_only` | Scan vulnerabilities only | No | `false` | **Allowed values**:</br>true</br>false |
 | `sbom_only` | Generate SBOM only | No | `false` | **Allowed values**:</br>true</br>false |
+| `scan_only` | Run scan without generating report output (FCS CLI 4.0.x+) | No | `false` | **Allowed values**:</br>true</br>false |
 | `strict_digest` | Enable strict digest validation</br>(requires FCS CLI 2.2.0+) | No | `false` | **Allowed values**:</br>true</br>false |
 
 > **Note on strict_digest:** When enabled, image scans enforce digest validation to ensure consistency between build and registry. The scan will fail if the image has uncompressed layers that cannot be pulled from a registry with correct digests. This feature helps with image traceability in compliance scenarios. When disabled (default), scans proceed with a warning if uncompressed layers are detected.
@@ -363,7 +400,7 @@ To change what triggers a non-zero exit code for image scans, update the image a
 ```
 <!-- x-release-please-end -->
 
-### Using the policy rule parameter
+### Disable cloud rules (air-gapped or firewall-restricted environments)
 <!-- x-release-please-start-version -->
 ```yaml
 - name: Run FCS IaC Scan
@@ -372,7 +409,7 @@ To change what triggers a non-zero exit code for image scans, update the image a
     falcon_client_id: ${{ vars.FALCON_CLIENT_ID }}
     falcon_region: 'us-2'
     path: './kubernetes'
-    policy_rule: 'default-iac-alert-rule'
+    disable_custom_rules: true
   env:
     FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
 ```

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ To use this action in your workflow, add the following step:
 | `upload_results` | Upload to Falcon Console | No | `false` | **Allowed values**:</br>true</br>false |
 | `verbose` | Enable verbose output | No | `false` | **Allowed values**:</br>true</br>false |
 | `profile` | Named profile from FCS CLI configuration | No | `default` | `production` |
-| `falcon_token` | Bearer token for Falcon API calls, skips OAuth2 | No | - | `BEARER <token>` |
+| `falcon_token` | Bearer token for Falcon API calls, skips OAuth2 | No | - | `<token>` |
 
 <details>
 <summary><strong>🛠️ IaC Scanning Parameters</strong> (Click to expand)</summary>

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
     required: false
     default: 'false'
   falcon_token:
-    description: 'Bearer token for Falcon API calls, skips OAuth2 authentication. Format: BEARER <token>'
+    description: 'Bearer token for Falcon API calls, skips OAuth2 authentication. Provide the token value only (no "BEARER " prefix)'
     required: false
   verbose:
     description: 'Enable verbose output'

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
     description: 'Include results for the specified platforms, accepts a comma-separated list (e.g Ansible,CloudFormation)'
     required: false
   policy_rule:
-    description: '(Deprecated, ignored as of FCS CLI 3.4.2) Cloud-based rules are now applied by default. Use disable_custom_rules to disable them.'
+    description: '(Deprecated, ignored as of FCS CLI v4.x.x) Cloud-based rules are now applied by default. Use disable_custom_rules to disable them.'
     required: false
     default: 'local'
   disable_custom_rules:

--- a/action.yml
+++ b/action.yml
@@ -56,9 +56,24 @@ inputs:
     description: 'Include results for the specified platforms, accepts a comma-separated list (e.g Ansible,CloudFormation)'
     required: false
   policy_rule:
-    description: 'IaC cloud scanning policy-rule. Use "local" for local rules, "default-iac-alert-rule" for cloud-based rules'
+    description: '(Deprecated, ignored as of FCS CLI 3.4.2) Cloud-based rules are now applied by default. Use disable_custom_rules to disable them.'
     required: false
     default: 'local'
+  disable_custom_rules:
+    description: 'Disable fetching cloud-based rules; scan with local rules only'
+    required: false
+    default: 'false'
+  exclude_gitignore:
+    description: 'Disable automatic exclusion of paths listed in .gitignore'
+    required: false
+    default: 'false'
+  max_file_size:
+    description: 'Maximum file size in megabytes for scanning (default 100)'
+    required: false
+  module_cache:
+    description: 'Reuse downloaded Terraform modules across scans via a persistent on-disk cache'
+    required: false
+    default: 'false'
   project_owners:
     description: 'Comma-separated list of project owners to notify (max 5)'
     required: false
@@ -78,6 +93,16 @@ inputs:
     description: 'Upload scan results to the CrowdStrike Falcon Console'
     required: false
     default: 'false'
+  falcon_token:
+    description: 'Bearer token for Falcon API calls, skips OAuth2 authentication. Format: BEARER <token>'
+    required: false
+  verbose:
+    description: 'Enable verbose output'
+    required: false
+    default: 'false'
+  profile:
+    description: 'Named profile from FCS CLI configuration'
+    required: false
   # Image scanning specific inputs
   image:
     description: 'Container image to scan (e.g., nginx:latest, docker://image:tag)'
@@ -133,6 +158,10 @@ inputs:
   temp_dir:
     description: 'Custom directory for temporary files'
     required: false
+  scan_only:
+    description: 'Run image scan without generating report output'
+    required: false
+    default: 'false'
   strict_digest:
     description: 'Enable strict digest validation for container images (enforces digest consistency between build and registry)'
     required: false
@@ -176,6 +205,13 @@ runs:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_PLATFORMS: ${{ inputs.platforms }}
         INPUT_POLICY_RULE: ${{ inputs.policy_rule }}
+        INPUT_DISABLE_CUSTOM_RULES: ${{ inputs.disable_custom_rules }}
+        INPUT_EXCLUDE_GITIGNORE: ${{ inputs.exclude_gitignore }}
+        INPUT_MAX_FILE_SIZE: ${{ inputs.max_file_size }}
+        INPUT_MODULE_CACHE: ${{ inputs.module_cache }}
+        INPUT_FALCON_TOKEN: ${{ inputs.falcon_token }}
+        INPUT_VERBOSE: ${{ inputs.verbose }}
+        INPUT_PROFILE: ${{ inputs.profile }}
         INPUT_PROJECT_OWNERS: ${{ inputs.project_owners }}
         INPUT_PROJECT_NAME: ${{ inputs.project_name }}
         INPUT_REPORT_FORMATS: ${{ inputs.report_formats }}
@@ -200,3 +236,4 @@ runs:
         INPUT_NO_COLOR: ${{ inputs.no_color }}
         INPUT_TEMP_DIR: ${{ inputs.temp_dir }}
         INPUT_STRICT_DIGEST: ${{ inputs.strict_digest }}
+        INPUT_SCAN_ONLY: ${{ inputs.scan_only }}

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -228,12 +228,14 @@ set_parameters() {
             "FAIL_ON:fail-on"
             "OUTPUT_PATH:output-path"
             "PLATFORMS:platforms"
-            "POLICY_RULE:policy-rule"
             "PROJECT_OWNERS:project-owners"
             "PROJECT_NAME:project-name"
             "REPORT_FORMATS:report-formats"
             "SEVERITIES:severities"
             "TIMEOUT:timeout"
+            "MAX_FILE_SIZE:max-file-size"
+            "FALCON_TOKEN:falcon-token"
+            "PROFILE:profile"
         )
 
         for param in "${input_params[@]}"; do
@@ -263,12 +265,44 @@ set_parameters() {
             die "Invalid value for 'disable-secrets-scan'. Should be 'true' or 'false'."
         fi
 
+        local disable_custom_rules
+        disable_custom_rules=$(validate_bool "${INPUT_DISABLE_CUSTOM_RULES:-}")
+        if [[ "$disable_custom_rules" == "true" ]]; then
+            params+=("--disable-custom-rules")
+        elif [[ "$disable_custom_rules" == "Invalid" ]]; then
+            die "Invalid value for 'disable-custom-rules'. Should be 'true' or 'false'."
+        fi
+
+        local exclude_gitignore
+        exclude_gitignore=$(validate_bool "${INPUT_EXCLUDE_GITIGNORE:-}")
+        if [[ "$exclude_gitignore" == "true" ]]; then
+            params+=("--exclude-gitignore")
+        elif [[ "$exclude_gitignore" == "Invalid" ]]; then
+            die "Invalid value for 'exclude-gitignore'. Should be 'true' or 'false'."
+        fi
+
+        local module_cache
+        module_cache=$(validate_bool "${INPUT_MODULE_CACHE:-}")
+        if [[ "$module_cache" == "true" ]]; then
+            params+=("--module-cache")
+        elif [[ "$module_cache" == "Invalid" ]]; then
+            die "Invalid value for 'module-cache'. Should be 'true' or 'false'."
+        fi
+
         local upload_results
         upload_results=$(validate_bool "${INPUT_UPLOAD_RESULTS:-}")
         if [[ "$upload_results" == "true" ]]; then
             params+=("--upload-results --client-id ${INPUT_FALCON_CLIENT_ID} --client-secret ${FALCON_CLIENT_SECRET} --falcon-region ${INPUT_FALCON_REGION}")
         elif [[ "$upload_results" == "Invalid" ]]; then
             die "Invalid value for 'upload-results'. Should be 'true' or 'false'."
+        fi
+
+        local verbose
+        verbose=$(validate_bool "${INPUT_VERBOSE:-}")
+        if [[ "$verbose" == "true" ]]; then
+            params+=("--verbose")
+        elif [[ "$verbose" == "Invalid" ]]; then
+            die "Invalid value for 'verbose'. Should be 'true' or 'false'."
         fi
 
     elif [[ "$scan_type" == "image" ]]; then
@@ -287,6 +321,8 @@ set_parameters() {
             "MINIMUM_DETECTION_SEVERITY:minimum-detection-severity"
             "TEMP_DIR:temp-dir"
             "TIMEOUT:timeout"
+            "FALCON_TOKEN:falcon-token"
+            "PROFILE:profile"
         )
 
         for param in "${input_params[@]}"; do
@@ -367,6 +403,22 @@ set_parameters() {
             params+=("--strict-digest")
         elif [[ "$strict_digest" == "Invalid" ]]; then
             die "Invalid value for 'strict-digest'. Should be 'true' or 'false'."
+        fi
+
+        local scan_only
+        scan_only=$(validate_bool "${INPUT_SCAN_ONLY:-}")
+        if [[ "$scan_only" == "true" ]]; then
+            params+=("--scan-only")
+        elif [[ "$scan_only" == "Invalid" ]]; then
+            die "Invalid value for 'scan-only'. Should be 'true' or 'false'."
+        fi
+
+        local verbose
+        verbose=$(validate_bool "${INPUT_VERBOSE:-}")
+        if [[ "$verbose" == "true" ]]; then
+            params+=("--verbose")
+        elif [[ "$verbose" == "Invalid" ]]; then
+            die "Invalid value for 'verbose'. Should be 'true' or 'false'."
         fi
 
         local upload_results

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -234,7 +234,6 @@ set_parameters() {
             "SEVERITIES:severities"
             "TIMEOUT:timeout"
             "MAX_FILE_SIZE:max-file-size"
-            "FALCON_TOKEN:falcon-token"
             "PROFILE:profile"
         )
 
@@ -321,7 +320,6 @@ set_parameters() {
             "MINIMUM_DETECTION_SEVERITY:minimum-detection-severity"
             "TEMP_DIR:temp-dir"
             "TIMEOUT:timeout"
-            "FALCON_TOKEN:falcon-token"
             "PROFILE:profile"
         )
 
@@ -440,14 +438,28 @@ execute_fcs_cli() {
 
     cd "$GITHUB_WORKSPACE" || die "Failed to change directory to $GITHUB_WORKSPACE"
 
+    # Build sensitive/quoted args separately so they survive word-splitting of
+    # $args and are never written to the log. A bearer token is passed as a
+    # single argument via a quoted array.
+    local -a secure_args=()
+    if [[ -n "${INPUT_FALCON_TOKEN:-}" ]]; then
+        secure_args+=("--falcon-token" "${INPUT_FALCON_TOKEN}")
+        # --falcon-token needs a region (or profile) to resolve the API base URL.
+        # The image param list already emits --falcon-region; add it for IaC when
+        # a token is supplied and no profile is set.
+        if [[ "$scan_type" == "iac" && -z "${INPUT_PROFILE:-}" && -n "${INPUT_FALCON_REGION:-}" ]]; then
+            secure_args+=("--falcon-region" "${INPUT_FALCON_REGION}")
+        fi
+    fi
+
     log "Executing FCS CLI tool with scan type '$scan_type' and arguments: $args"
 
     if [[ "$scan_type" == "iac" ]]; then
         # shellcheck disable=SC2086
-        $FCS_CLI_BIN scan iac $args 2>&1 | tee "$output_file"
+        $FCS_CLI_BIN scan iac $args "${secure_args[@]}" 2>&1 | tee "$output_file"
     elif [[ "$scan_type" == "image" ]]; then
         # shellcheck disable=SC2086
-        $FCS_CLI_BIN scan image $INPUT_IMAGE $args 2>&1 | tee "$output_file"
+        $FCS_CLI_BIN scan image $INPUT_IMAGE $args "${secure_args[@]}" 2>&1 | tee "$output_file"
     else
         die "Invalid scan_type '$scan_type'. Must be 'iac' or 'image'."
     fi


### PR DESCRIPTION
Summary
  
- --policy-rule deprecated: Removed from action args — the flag is ignored by FCS CLI 4.0.x and cloud rules are now applied by default. Replaced policy_rule input with disable_custom_rules for users who need to opt out.
- New inputs (4.0.x): Added support for disable_custom_rules, exclude_gitignore, max_file_size, module_cache (IaC), scan_only (image), and verbose, profile, falcon_token (both scan types).                                                                                                                                                        
   
Testing                                                                                                                                                                 
                  
- IaC scan with disable_custom_rules: true — verify --disable-custom-rules in CLI args, --policy-rule absent                                                              
- IaC scan without new flags — verify no regression against FCS CLI < 4.0.x (new flags only passed when explicitly set)
- Image scan with scan_only: true and verbose: true — verify flags appear in args