### PR TITLE
fix: correct falcon_token handling in fcs-scan.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ To use this action in your workflow, add the following step:
 | `upload_results` | Upload to Falcon Console | No | `false` | **Allowed values**:</br>true</br>false |
 | `verbose` | Enable verbose output | No | `false` | **Allowed values**:</br>true</br>false |
 | `profile` | Named profile from FCS CLI configuration | No | `default` | `production` |
-| `falcon_token` | Bearer token for Falcon API calls, skips OAuth2 | No | - | `BEARER <token>` |
+| `falcon_token` | Bearer token for Falcon API calls, skips OAuth2 | No | - | `<token>` |
 
 <details>
 <summary><strong>🛠️ IaC Scanning Parameters</strong> (Click to expand)</summary>

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
     required: false
     default: 'false'
   falcon_token:
-    description: 'Bearer token for Falcon API calls, skips OAuth2 authentication. Format: BEARER <token>'
+    description: 'Bearer token for Falcon API calls, skips OAuth2 authentication. Provide the token value only (no "BEARER " prefix)'
     required: false
   verbose:
     description: 'Enable verbose output'

--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -234,7 +234,6 @@ set_parameters() {
             "SEVERITIES:severities"
             "TIMEOUT:timeout"
             "MAX_FILE_SIZE:max-file-size"
-            "FALCON_TOKEN:falcon-token"
             "PROFILE:profile"
         )
 
@@ -321,7 +320,6 @@ set_parameters() {
             "MINIMUM_DETECTION_SEVERITY:minimum-detection-severity"
             "TEMP_DIR:temp-dir"
             "TIMEOUT:timeout"
-            "FALCON_TOKEN:falcon-token"
             "PROFILE:profile"
         )
 
@@ -440,14 +438,28 @@ execute_fcs_cli() {
 
     cd "$GITHUB_WORKSPACE" || die "Failed to change directory to $GITHUB_WORKSPACE"
 
+    # Build sensitive/quoted args separately so they survive word-splitting of
+    # $args and are never written to the log. A bearer token is passed as a
+    # single argument via a quoted array.
+    local -a secure_args=()
+    if [[ -n "${INPUT_FALCON_TOKEN:-}" ]]; then
+        secure_args+=("--falcon-token" "${INPUT_FALCON_TOKEN}")
+        # --falcon-token needs a region (or profile) to resolve the API base URL.
+        # The image param list already emits --falcon-region; add it for IaC when
+        # a token is supplied and no profile is set.
+        if [[ "$scan_type" == "iac" && -z "${INPUT_PROFILE:-}" && -n "${INPUT_FALCON_REGION:-}" ]]; then
+            secure_args+=("--falcon-region" "${INPUT_FALCON_REGION}")
+        fi
+    fi
+
     log "Executing FCS CLI tool with scan type '$scan_type' and arguments: $args"
 
     if [[ "$scan_type" == "iac" ]]; then
         # shellcheck disable=SC2086
-        $FCS_CLI_BIN scan iac $args 2>&1 | tee "$output_file"
+        $FCS_CLI_BIN scan iac $args "${secure_args[@]}" 2>&1 | tee "$output_file"
     elif [[ "$scan_type" == "image" ]]; then
         # shellcheck disable=SC2086
-        $FCS_CLI_BIN scan image $INPUT_IMAGE $args 2>&1 | tee "$output_file"
+        $FCS_CLI_BIN scan image $INPUT_IMAGE $args "${secure_args[@]}" 2>&1 | tee "$output_file"
     else
         die "Invalid scan_type '$scan_type'. Must be 'iac' or 'image'."
     fi


### PR DESCRIPTION
While reviewing #82 I tested the new `falcon_token` input against a live FCS CLI and hit a couple of issues, so I put together fixes here targeting the PR branch so they're easy to pull in.

The token was being folded into the space-joined `$args` string that `execute_fcs_cli` re-expands unquoted. The documented `BEARER <token>` format contains a space, so it got split and the CLI treated the token half as a scan target (`invalid target path: <token>`). This moves the token into a quoted array passed as a single argument, which also keeps it out of the `Executing FCS CLI...` log line where it was otherwise printed in cleartext.

Separately, IaC scans never passed `--falcon-region`, but the CLI requires a region (or a configured profile) to resolve the API base URL when `--falcon-token` is used. Without it the scan silently fell back to local rules only. The image path already sends the region; this adds it for IaC when a token is set and no profile is given.

Also dropped the `BEARER ` prefix from the docs since the CLI accepts the bare token and the bare form avoids the space entirely.

Verified live against FCS CLI 3.4.2 with real credentials: a token now authenticates on IaC ("Fetching custom rules from Falcon Cloud"), no token appears in the logs, and scans without a token are unchanged.