### PR TITLE
fix: convert SARIF when output_path is a directory

### DIFF
--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -76,6 +76,16 @@ convert_json_to_sarif() {
             # Exact file exists (single-arch or IaC)
             all_json_files="$output_path"
             log "convert_json_to_sarif: Fallback found exact file: $output_path"
+        elif [[ -d "$output_path" ]]; then
+            # output_path is a directory — search inside it for JSON files
+            local found_files
+            found_files=$(find "$output_path" -maxdepth 1 -name "*.json" 2>/dev/null | sort)
+            if [[ -n "$found_files" ]]; then
+                all_json_files="$found_files"
+                log "convert_json_to_sarif: Fallback found JSON files in directory: $(echo "$found_files" | tr '\n' ' ')"
+            else
+                log "convert_json_to_sarif: Fallback: no JSON files found in directory $output_path" "WARN"
+            fi
         else
             # Try multi-arch pattern: CLI uses output_path as a prefix and appends arch suffixes
             local dir_path

--- a/tests/test-image-scan.sh
+++ b/tests/test-image-scan.sh
@@ -541,6 +541,81 @@ Scan complete. No issues found."
         "$fb_dir2/results.json_linux_arm64.json"
     rm -rf "$fb_dir2"
 
+    # ============================================================
+    # SARIF Discovery: Directory output_path fallback (IaC scan)
+    # Regression test for: output_path is a directory (e.g. './scan-results'),
+    # CLI writes JSON files inside it, but primary stdout parse finds nothing.
+    # ============================================================
+
+    test_sarif_discovery_fallback_directory() {
+        local test_name="$1"
+        local input_output_path="$2"
+        local expected_sarif="$3"
+        shift 3
+        local json_files=("$@")
+
+        log "Testing SARIF fallback (directory): $test_name"
+
+        # Create mock JSON file(s) inside the directory
+        for f in "${json_files[@]}"; do
+            mkdir -p "$(dirname "$f")"
+            echo '{"fcs_version":"5.0.1","rule_detections":[]}' > "$f"
+        done
+
+        # CLI output has NO "Results saved to file:" — simulates the failing scenario
+        local cli_output_file="/tmp/sarif_dir_cli_output_$$.txt"
+        echo "Scanning IaC path ...." > "$cli_output_file"
+        echo "Scan complete." >> "$cli_output_file"
+
+        local result
+        result=$(
+            export GITHUB_ACTION_PATH="$PROJECT_ROOT"
+            export INPUT_OUTPUT_PATH="$input_output_path"
+            export FCS_CLI_OUTPUT_FILE="$cli_output_file"
+
+            source <(grep -A 200 '^convert_json_to_sarif()' "$FCS_SCAN_SCRIPT" | \
+                     awk '/^convert_json_to_sarif\(\)/{found=1} found{print; brace+=gsub(/{/,""); brace-=gsub(/}/,""); if(found && brace==0) exit}')
+            source <(grep -A 5 '^log()' "$FCS_SCAN_SCRIPT")
+
+            convert_json_to_sarif 2>&1
+        )
+
+        rm -f "$cli_output_file"
+
+        if [[ -f "$expected_sarif" ]]; then
+            echo -e "  ${GREEN}✓${NC} Directory fallback produced expected SARIF file: $expected_sarif"
+        else
+            error "Directory fallback did NOT produce expected SARIF file: $expected_sarif"
+            error "Function output: $result"
+            for f in "${json_files[@]}"; do rm -f "$f" "${f%.json}.sarif"; done
+            return 1
+        fi
+
+        for f in "${json_files[@]}"; do rm -f "$f" "${f%.json}.sarif"; done
+        echo
+    }
+
+    # Test 18: IaC scan — directory output_path, single JSON written by CLI inside it
+    local scan_dir="/tmp/scan-results-$$"
+    mkdir -p "$scan_dir"
+    test_sarif_discovery_fallback_directory \
+        "Fallback: directory output_path with single JSON inside" \
+        "$scan_dir" \
+        "$scan_dir/scan-results.sarif" \
+        "$scan_dir/scan-results.json"
+    rm -rf "$scan_dir"
+
+    # Test 19: IaC scan — directory output_path, multiple JSON files inside
+    local scan_dir2="/tmp/scan-results2-$$"
+    mkdir -p "$scan_dir2"
+    test_sarif_discovery_fallback_directory \
+        "Fallback: directory output_path with multiple JSON files inside" \
+        "$scan_dir2" \
+        "$scan_dir2/iac-results.sarif" \
+        "$scan_dir2/iac-results.json" \
+        "$scan_dir2/secrets-results.json"
+    rm -rf "$scan_dir2"
+
     log "All tests completed successfully!"
     log "Image scanning functionality is working correctly."
     


### PR DESCRIPTION
When output_path is a directory (e.g. './scan-results'), the fallback file discovery in convert_json_to_sarif was incorrectly splitting the path — dirname('.') / basename('scan-results') — then searching for 'scan-results*.json' in '.', missing the JSON files written inside the directory by the CLI.

Adds a [[ -d ]] check before the multi-arch prefix glob so that when output_path is an existing directory, files inside it are found and converted to SARIF correctly.

Regression tests added for the directory fallback case (tests 18 & 19 in tests/test-image-scan.sh).