### PR TITLE
fix: strip ANSI codes and rewrite .sarif output path for SARIF conversion

### DIFF
--- a/fcs-scan.sh
+++ b/fcs-scan.sh
@@ -46,8 +46,12 @@ convert_json_to_sarif() {
     if [[ -f "$FCS_CLI_OUTPUT_FILE" ]]; then
         log "convert_json_to_sarif: Parsing CLI output from $FCS_CLI_OUTPUT_FILE"
 
-        # Extract file paths from "Results saved to file: <path>" lines
+        # Extract file paths from "Results saved to file: <path>" lines.
+        # Strip ANSI escape codes (CLI bolds these lines) and carriage returns
+        # (\r from progress bar) before extracting the path.
         all_json_files=$(grep "Results saved to file:" "$FCS_CLI_OUTPUT_FILE" | \
+                        sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | \
+                        tr -d '\r' | \
                         sed 's/.*Results saved to file: //' | \
                         grep '\.json$' | \
                         sort)
@@ -284,10 +288,15 @@ set_parameters() {
             local input_var="INPUT_${param%%:*}"
             local param_name="${param#*:}"
             if [[ -n "${!input_var:-}" ]]; then
-                # Special handling for output path - ensure directory exists
+                # Special handling for output path - ensure directory exists and change .sarif to .json
                 if [[ "$param_name" == "output-path" ]]; then
-                    ensure_output_directory "${!input_var}"
-                    params+=("--${param_name} ${!input_var}")
+                    local output_value="${!input_var}"
+                    ensure_output_directory "$output_value"
+                    if [[ "$output_value" == *.sarif ]]; then
+                        output_value="${output_value%.sarif}.json"
+                        log "Output path changed from ${!input_var} to ${output_value} to ensure JSON generation"
+                    fi
+                    params+=("--${param_name} ${output_value}")
                 # Special handling for report formats - replace sarif with json if needed
                 elif [[ "$param_name" == "report-formats" ]]; then
                     local prepared_formats

--- a/tests/test-image-scan.sh
+++ b/tests/test-image-scan.sh
@@ -616,6 +616,174 @@ Scan complete. No issues found."
         "$scan_dir2/secrets-results.json"
     rm -rf "$scan_dir2"
 
+    # ============================================================
+    # IaC output-path .sarif → .json rewrite in set_parameters
+    # Regression test for: report_formats='sarif', output_path='./results.sarif'
+    # The IaC set_parameters must rewrite the path to .json before passing to
+    # the CLI, otherwise the CLI writes to .sarif and convert_json_to_sarif
+    # can't find the file.
+    # ============================================================
+
+    test_iac_sarif_output_path_rewrite() {
+        local test_name="$1"
+        local input_output_path="$2"
+        local expected_param="$3"
+
+        log "Testing IaC output-path rewrite: $test_name"
+
+        local result
+        result=$(
+            export INPUT_SCAN_TYPE="iac"
+            export INPUT_PATH="."
+            export INPUT_OUTPUT_PATH="$input_output_path"
+            export INPUT_REPORT_FORMATS="sarif"
+            export INPUT_FALCON_CLIENT_ID="test-id"
+            export FALCON_CLIENT_SECRET="test-secret"
+            export INPUT_FALCON_REGION="us-1"
+
+            source <(grep -A 300 '^set_parameters()' "$FCS_SCAN_SCRIPT" | \
+                     awk '/^set_parameters\(\)/{found=1} found{print; brace+=gsub(/{/,""); brace-=gsub(/}/,""); if(found && brace==0) exit}')
+            source <(grep -A 5 '^validate_bool()' "$FCS_SCAN_SCRIPT")
+            source <(grep -A 20 '^prepare_report_formats_for_cli()' "$FCS_SCAN_SCRIPT")
+            source <(grep -A 20 '^ensure_output_directory()' "$FCS_SCAN_SCRIPT")
+            log() { echo "$@" >&2; }
+            die() { echo "ERROR: $*" >&2; exit 1; }
+
+            set_parameters 2>/dev/null
+        )
+
+        if [[ "$result" == *"$expected_param"* ]]; then
+            echo -e "  ${GREEN}✓${NC} set_parameters contains: $expected_param"
+        else
+            error "set_parameters did not contain: $expected_param"
+            error "Actual params: $result"
+            return 1
+        fi
+        echo
+    }
+
+    # Test 20: IaC .sarif output_path must be rewritten to .json
+    test_iac_sarif_output_path_rewrite \
+        "IaC .sarif output_path rewritten to .json" \
+        "/tmp/results.sarif" \
+        "--output-path /tmp/results.json"
+
+    # Test 21: IaC .json output_path must be passed through unchanged
+    test_iac_sarif_output_path_rewrite \
+        "IaC .json output_path passed through unchanged" \
+        "/tmp/results.json" \
+        "--output-path /tmp/results.json"
+
+    # ============================================================
+    # No output_path: primary stdout parse is the only mechanism
+    # Tests #1/#5 (IaC) and #9/#13 (image) — scan type is irrelevant
+    # since convert_json_to_sarif is shared. Covers both the happy
+    # path (CLI emits "Results saved to file:") and the known failure
+    # path (CLI does not emit it).
+    # ============================================================
+
+    test_sarif_no_output_path() {
+        local test_name="$1"
+        local cli_output_content="$2"
+        local json_file="$3"
+        local expect_sarif="$4"   # "true" or "false"
+
+        log "Testing SARIF conversion (no output_path): $test_name"
+
+        local cli_output_file="/tmp/sarif_no_op_cli_$$.txt"
+        echo "$cli_output_content" > "$cli_output_file"
+
+        # Create mock JSON file if provided
+        if [[ -n "$json_file" ]]; then
+            mkdir -p "$(dirname "$json_file")"
+            echo '{"fcs_version":"5.0.1","rule_detections":[]}' > "$json_file"
+        fi
+
+        local sarif_file="${json_file%.json}.sarif"
+
+        local result
+        result=$(
+            export GITHUB_ACTION_PATH="$PROJECT_ROOT"
+            export INPUT_OUTPUT_PATH=""
+            export FCS_CLI_OUTPUT_FILE="$cli_output_file"
+
+            source <(grep -A 200 '^convert_json_to_sarif()' "$FCS_SCAN_SCRIPT" | \
+                     awk '/^convert_json_to_sarif\(\)/{found=1} found{print; brace+=gsub(/{/,""); brace-=gsub(/}/,""); if(found && brace==0) exit}')
+            source <(grep -A 5 '^log()' "$FCS_SCAN_SCRIPT")
+
+            convert_json_to_sarif 2>&1
+        )
+
+        rm -f "$cli_output_file"
+
+        if [[ "$expect_sarif" == "true" ]]; then
+            if [[ -f "$sarif_file" ]]; then
+                echo -e "  ${GREEN}✓${NC} SARIF file produced via stdout parse: $sarif_file"
+                rm -f "$json_file" "$sarif_file"
+            else
+                error "Expected SARIF file not found: $sarif_file"
+                error "Function output: $result"
+                rm -f "$json_file"
+                return 1
+            fi
+        else
+            if [[ ! -f "$sarif_file" ]]; then
+                echo -e "  ${GREEN}✓${NC} No SARIF produced as expected (stdout parse found nothing)"
+            else
+                error "SARIF file should not have been produced: $sarif_file"
+                rm -f "$json_file" "$sarif_file"
+                return 1
+            fi
+        fi
+        echo
+    }
+
+    # Test 22: no output_path, CLI emits "Results saved to file:" with ANSI bold codes and \r
+    local no_op_json="/tmp/sarif_no_op_$$/results.json"
+    mkdir -p "$(dirname "$no_op_json")"
+    test_sarif_no_output_path \
+        "No output_path: stdout parse handles ANSI codes and \\r from progress bar" \
+        "$(printf 'Scan progress: 100%%\r\033[1mResults saved to file: %s\033[0m' "$no_op_json")" \
+        "$no_op_json" \
+        "true"
+    rm -rf "$(dirname "$no_op_json")"
+
+    # Test 23: no output_path, CLI emits nothing useful — known silent failure
+    test_sarif_no_output_path \
+        "No output_path: stdout parse finds nothing (known limitation)" \
+        "Scanning...
+Done." \
+        "" \
+        "false"
+
+    # ============================================================
+    # Image scan + directory output_path (#10/#14)
+    # convert_json_to_sarif is scan-type agnostic so the directory
+    # fallback logic is identical to IaC — this test confirms the
+    # image parameter naming difference doesn't affect conversion.
+    # ============================================================
+
+    # Test 24: image scan — directory output_path, single JSON inside
+    local img_dir="/tmp/img-scan-results-$$"
+    mkdir -p "$img_dir"
+    test_sarif_discovery_fallback_directory \
+        "Image scan: directory output_path with single JSON inside" \
+        "$img_dir" \
+        "$img_dir/image-results.sarif" \
+        "$img_dir/image-results.json"
+    rm -rf "$img_dir"
+
+    # Test 25: image scan — directory output_path, multiple JSON files (multi-arch)
+    local img_dir2="/tmp/img-scan-results2-$$"
+    mkdir -p "$img_dir2"
+    test_sarif_discovery_fallback_directory \
+        "Image scan: directory output_path with multi-arch JSON files" \
+        "$img_dir2" \
+        "$img_dir2/results_linux_amd64.sarif" \
+        "$img_dir2/results_linux_amd64.json" \
+        "$img_dir2/results_linux_arm64.json"
+    rm -rf "$img_dir2"
+
     log "All tests completed successfully!"
     log "Image scanning functionality is working correctly."
     


### PR DESCRIPTION
## Summary

- **Bug 1 — ANSI escape codes in CLI stdout** (`no output_path` case): The FCS CLI wraps the `Results saved to file:` line in ANSI bold codes (`\033[1m...\033[0m`) and may prefix it with a carriage return (`\r`) from a progress bar. After stripping the `Results saved to file: ` prefix with `sed`, the captured path retained the trailing `\033[0m` suffix, causing the `grep '\.json$'` filter to silently drop every match. Fix: pipe the grep output through `sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'` and `tr -d '\r'` before extracting the path.

- **Bug 2 — IaC `.sarif` output path not rewritten** (`report_formats: 'sarif'`, `output_path: './results.sarif'` case): The IaC branch of `set_parameters` forwarded the `.sarif` path to the CLI unchanged. The CLI wrote JSON content to that `.sarif` path; `convert_json_to_sarif` then searched for a `.json` file and found nothing. Fix: rewrite any `.sarif` suffix to `.json` in the IaC `output-path` handling — matching the existing behaviour already present for image scans.

Both bugs produce the same "No json files found" error message, which was the symptom reported by customers on v5.0.1 (a third cause — directory fallback — was already fixed in v5.0.2).

> **Known limitation (no regression):** When no `output_path` is specified and the CLI does not emit a `Results saved to file:` line (e.g. when `report_formats` is omitted), `convert_json_to_sarif` cannot locate the output and produces no SARIF. Customers should specify `output_path` when SARIF conversion is needed.

## Test plan

- [ ] Tests 20–21: `test_iac_sarif_output_path_rewrite` — verify `.sarif` → `.json` rewrite and `.json` passthrough in `set_parameters`
- [ ] Test 22: `test_sarif_no_output_path` — CLI output with ANSI bold codes and `\r` is parsed correctly
- [ ] Test 23: `test_sarif_no_output_path` — no useful CLI output produces no SARIF (known limitation, no crash)
- [ ] Tests 24–25: image scan with directory `output_path` (single JSON and multi-arch) — confirms directory fallback works regardless of scan type
- [ ] Run full unit test suite: `bash tests/test-image-scan.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)